### PR TITLE
prevent call on nil when transaction was closed

### DIFF
--- a/lib/new_relic/agent/instrumentation/middleware_tracing.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_tracing.rb
@@ -57,7 +57,7 @@ module NewRelic
               result = target.call(env)
             end
 
-            if result.is_a?(Array)
+            if result.is_a?(Array) && state.current_transaction
               state.current_transaction.http_response_code = result[0]
             end
 


### PR DESCRIPTION
Transaction can be closed from within the application (for example on Rack::Timeout error).
Then it tried to call `http_response_code` on nil.

> , [2014-11-18T12:26:43.036412 #28322] ERROR -- : app error: undefined method `http_response_code=' for nil:NilClass (NoMethodError)
> E, [2014-11-18T12:26:43.036617 #28322] ERROR -- : /home/bender/brain/shared/bundle/ruby/2.1.0/gems/newrelic_rpm-3.9.7.266/lib/new_relic/agent/instrumentation/middleware_tracing.rb:61:in `call'
> E, [2014-11-18T12:26:43.036738 #28322] ERROR -- : /home/bender/brain/shared/bundle/ruby/2.1.0/gems/unicorn-4.8.3/lib/unicorn/http_server.rb:576:in `process_client'