### PR TITLE
Added intrumentation for CAS variants of Dalli methods

### DIFF
--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -77,6 +77,7 @@ DependencyDetection.defer do
       ::NewRelic::Agent.logger.info 'Installing Memcached instrumentation'
     end
     if defined? ::Dalli::Client
+      commands += %w[cas get_cas get_multi_cas set_cas replace_cas delete_cas]
       NewRelic::Agent::Instrumentation::Memcache.instrument_methods(::Dalli::Client,
                                                                     commands)
       ::NewRelic::Agent.logger.info 'Installing Dalli Memcache instrumentation'


### PR DESCRIPTION
Dalli::Clients has variants of many of its normal methods that either
return or use the revision number from Memcached that can be used for
compare-and-swap operations. Instrumenting these methods ensures that
the information that NewRelic gets is not biases by their absence.