### PR TITLE
allow hostname to be overridden in config file

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1173,6 +1173,13 @@ module NewRelic
           :public       => true,
           :type         => Boolean,
           :description  => 'Disables installation of Grape instrumentation.'
+        },
+        :hostname => {
+          :default      => nil,
+          :allow_nil    => true,
+          :public       => true,
+          :type         => String,
+          :description  => 'Override automatic hostname detection.'
         }
       }.freeze
     end

--- a/lib/new_relic/agent/hostname.rb
+++ b/lib/new_relic/agent/hostname.rb
@@ -7,7 +7,10 @@ module NewRelic
     module Hostname
       def self.get
         dyno_name = ENV['DYNO']
-        if dyno_name && ::NewRelic::Agent.config[:'heroku.use_dyno_names']
+        hostname = NewRelic::Agent.config[:hostname]
+        if hostname
+          return hostname
+        elsif dyno_name && ::NewRelic::Agent.config[:'heroku.use_dyno_names']
           matching_prefix = heroku_dyno_name_prefix(dyno_name)
           dyno_name = "#{matching_prefix}.*" if matching_prefix
           dyno_name

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -80,6 +80,18 @@ module NewRelic
         end
       end
 
+      def test_config_hostname_overrides_socket_hostname
+        with_config(:hostname => 'Karningul') do
+          assert_equal 'Karningul', NewRelic::Agent::Hostname.get
+        end
+      end
+
+      def test_config_hostname_overrides_dyno_name
+        with_dyno_name('Imladris', :hostname => 'Karningul', :'heroku.use_dyno_names' => true) do
+          assert_equal 'Karningul', NewRelic::Agent::Hostname.get
+        end
+      end
+
       def with_dyno_name(dyno_name, config_options)
         with_config(config_options) do
           ENV['DYNO'] = dyno_name


### PR DESCRIPTION
we have a bunch of servers named 'app1'. They all have unique FQDNs though. The problem is that in the NR web interface they are all just 'app1', and they also don't match up with our nrsysmond servers because those are properly configured to use the fqdn. This allows us to override the hostname ourselves, which we'll do when we generate the newrelic.yml file using puppet.