### PR TITLE
Test case to show if rescue_from is used in grape, request params aren't set.

### DIFF
--- a/test/multiverse/suites/grape/grape_test.rb
+++ b/test/multiverse/suites/grape/grape_test.rb
@@ -100,6 +100,23 @@ class GrapeTest < Minitest::Test
       end
     end
 
+    def test_post_body_params_are_captured_with_error
+      with_config(:capture_params => true) do
+        assert_raises(GrapeTestApiError) do
+          post '/grape_ape_fail', {'q' => '1234', 'foo' => 'fail'}.to_json, "CONTENT_TYPE" => "application/json"
+        end
+
+        assert_equal({'q' => '1234', 'foo' => 'fail'}, last_traced_error_request_params)
+      end
+    end
+
+    def test_post_body_params_are_captured_with_rescue_from
+      with_config(:capture_params => true) do
+        post '/grape_ape_fail_rescue', {'q' => '1234', 'foo' => 'fail'}.to_json, "CONTENT_TYPE" => "application/json"
+        assert_equal({'q' => '1234', 'foo' => 'fail'}, last_traced_error_request_params)
+      end
+    end
+
     def test_post_body_with_nested_params_are_captured
       with_config(:capture_params => true) do
         params = {"ape" => {"first_name" => "koko", "last_name" => "gorilla"}}

--- a/test/multiverse/suites/grape/grape_test_api.rb
+++ b/test/multiverse/suites/grape/grape_test_api.rb
@@ -45,4 +45,20 @@ class GrapeTestApi < Grape::API
       'Destroy grape ape!'
     end
   end
+
+  resource :grape_ape_fail do
+    post do
+      raise GrapeTestApiError.new("I'm sorry Dave, I'm afraid I can't do that.")
+    end
+  end
+
+  resource :grape_ape_fail_rescue do
+    rescue_from :all do |e|
+      error_response({ message: "rescued from #{e.class.name}" })
+    end
+
+    post do
+      raise GrapeTestApiError.new("I'm sorry Dave, I'm afraid I can't do that.")
+    end
+  end
 end


### PR DESCRIPTION
Added test cases to demonstrate that newrelic_rpm doesn't capture params if grape controller uses rescue_from.