### PR TITLE
Add in-line comment fixture

### DIFF
--- a/test/fixtures/cross_agent_tests/sql_obfuscation/sql_obfuscation.json
+++ b/test/fixtures/cross_agent_tests/sql_obfuscation/sql_obfuscation.json
@@ -292,6 +292,18 @@
     "pathological": true
   },
   {
+    "name": "pathological/inline_comments",
+    "obfuscated": [
+      "SELECT ? ? + ?"
+    ],
+    "dialects": [
+      "mysql",
+      "postgres"
+    ],
+    "sql": "SELECT 1 /* this is an in-line comment */ + 1",
+    "pathological": true
+  },
+  {
     "name": "pathological/mixed_comments_and_quotes",
     "obfuscated": [
       "SELECT * FROM t WHERE ?"


### PR DESCRIPTION
This commit adds a new fixture that demonstrates the expected behavior
using a query from the MySQL documentation page on comments:
https://dev.mysql.com/doc/refman/5.6/en/comments.html