### PR TITLE
include non-default ports in host

### DIFF
--- a/lib/new_relic/agent/http_clients/curb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/curb_wrappers.rb
@@ -16,7 +16,7 @@ module NewRelic
         end
 
         def host
-          self["host"] || self["Host"] || self.uri.host
+          self["host"] || self["Host"] || "#{self.uri.host}#{':' << self.uri.port.to_s if self.uri.port != self.uri.default_port}"
         end
 
         def method


### PR DESCRIPTION
This is a really ugly and incomplete way of achieving what I'm after, but I wanted to at least start some discussion about this.

At SK, we have a lot of internal services running off of one hostname, but on different, non-default ports. When the agent captures requests made through our HTTP Client (curb) for the External Services report, they all just get lumped under that single hostname.

This would allow one to look into requests to `http://host.name:1234` separately from requests to  `http://host.name:4321`.

Is there a neater way we could implement this across the board for all http clients?