### PR TITLE
Integration with MongoDB Ruby Driver 2.1

### DIFF
--- a/lib/new_relic/agent/datastores/mongo.rb
+++ b/lib/new_relic/agent/datastores/mongo.rb
@@ -8,15 +8,11 @@ module NewRelic
       module Mongo
         def self.is_supported_version?
           # No version constant in < 2.0 versions of Mongo :(
-          defined?(::Mongo) &&
-            defined?(::Mongo::MongoClient) &&
-            !is_version2?
+          defined?(::Mongo) && (defined?(::Mongo::MongoClient) || is_monitoring_enabled?)
         end
 
-        # At present we explicitly don't support version 2.x of the driver yet
-        def self.is_version2?
-          defined?(::Mongo::VERSION) &&
-            NewRelic::VersionNumber.new(::Mongo::VERSION) > NewRelic::VersionNumber.new("2.0.0")
+        def self.is_monitoring_enabled?
+          defined?(::Mongo::Monitoring)
         end
 
         def self.is_version_1_10_or_later?

--- a/lib/new_relic/agent/instrumentation/mongo.rb
+++ b/lib/new_relic/agent/instrumentation/mongo.rb
@@ -23,37 +23,9 @@ DependencyDetection.defer do
     end
   end
 
-  class CommandSubscriber
-
-    def started(event)
-      operations[event.operation_id] = event
-    end
-
-    def succeeded(event)
-      started_event = operations.delete(event.operation_id)
-      NewRelic::Agent.instance.transaction_sampler.notice_nosql_statement(
-        format_statement(started_event.command), event.duration
-      )
-    end
-
-    def failed(event)
-      started_event = operations.delete(event.operation_id)
-      # How does new relic want to handle failures?
-    end
-
-    private
-
-    def operations
-      @operations ||= {}
-    end
-
-    def format_statement(event)
-      "#{event.database_name}.#{event.command_name} #{event.command.inspect}"
-    end
-  end
-
   def install_mongo_command_subscriber
-    Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, CommandSubscriber.new)
+    require 'new_relic/agent/instrumentation/mongodb_command_subscriber'
+    Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, MongodbCommandSubscriber.new)
   end
 
   def install_mongo_instrumentation

--- a/lib/new_relic/agent/instrumentation/mongo.rb
+++ b/lib/new_relic/agent/instrumentation/mongo.rb
@@ -25,7 +25,10 @@ DependencyDetection.defer do
 
   def install_mongo_command_subscriber
     require 'new_relic/agent/instrumentation/mongodb_command_subscriber'
-    Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, MongodbCommandSubscriber.new)
+    Mongo::Monitoring::Global.subscribe(
+      Mongo::Monitoring::COMMAND,
+      NewRelic::Agent::Instrumentation::MongodbCommandSubscriber.new
+    )
   end
 
   def install_mongo_instrumentation

--- a/lib/new_relic/agent/instrumentation/mongo.rb
+++ b/lib/new_relic/agent/instrumentation/mongo.rb
@@ -16,7 +16,44 @@ DependencyDetection.defer do
 
   executes do
     NewRelic::Agent.logger.info 'Installing Mongo instrumentation'
-    install_mongo_instrumentation
+    if NewRelic::Agent::Datastores::Mongo.is_monitoring_enabled?
+      install_mongo_command_subscriber
+    else
+      install_mongo_instrumentation
+    end
+  end
+
+  class CommandSubscriber
+
+    def started(event)
+      operations[event.operation_id] = event
+    end
+
+    def succeeded(event)
+      started_event = operations.delete(event.operation_id)
+      NewRelic::Agent.instance.transaction_sampler.notice_nosql_statement(
+        format_statement(started_event.command), event.duration
+      )
+    end
+
+    def failed(event)
+      started_event = operations.delete(event.operation_id)
+      # How does new relic want to handle failures?
+    end
+
+    private
+
+    def operations
+      @operations ||= {}
+    end
+
+    def format_statement(event)
+      "#{event.database_name}.#{event.command_name} #{event.command.inspect}"
+    end
+  end
+
+  def install_mongo_command_subscriber
+    Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, CommandSubscriber.new)
   end
 
   def install_mongo_instrumentation

--- a/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
@@ -1,0 +1,68 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+module NewRelic
+  module Agent
+    module Instrumentation
+      class MongodbCommandSubscriber
+
+        MONGODB = 'MongoDB'.freeze
+
+        def started(event)
+          begin
+            return unless NewRelic::Agent.tl_is_execution_traced?
+            operations[event.operation_id] = event
+          rescue Exception => e
+            log_notification_error('started', e)
+          end
+        end
+
+        def completed(event)
+          begin
+            state = NewRelic::Agent::TransactionState.tl_get
+            return unless state.is_execution_traced?
+            started_event = operations.delete(event.operation_id)
+
+            base, *other_metrics = metrics(started_event)
+
+            NewRelic::Agent.instance.stats_engine.tl_record_scoped_and_unscoped_metrics(
+              base, other_metrics, event.duration
+            )
+
+            NewRelic::Agent.instance.transaction_sampler.notice_nosql_statement(
+              format_statement(started_event), event.duration
+            )
+          rescue Exception => e
+            log_notification_error('completed', e)
+          end
+        end
+
+        alias :succeeded :completed
+        alias :failed :completed
+
+        private
+
+        def collection(event)
+          event.command.values.first
+        end
+
+        def metrics(event)
+          NewRelic::Agent::Datastores::MetricHelper.metrics_for(MONGODB, event.command_name, collection(event))
+        end
+
+        def log_notification_error(event_type, error)
+          NewRelic::Agent.logger.error("Error during MongoDB #{event_type} event:")
+          NewRelic::Agent.logger.log_exception(:error, error)
+        end
+
+        def operations
+          @operations ||= {}
+        end
+
+        def format_statement(event)
+          "#{event.database_name}.#{event.command_name} #{event.command}"
+        end
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
@@ -6,7 +6,6 @@ require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','test_h
 require 'new_relic/agent/instrumentation/mongodb_command_subscriber'
 
 class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest::Test
-  class Order; end
 
   def setup
     @started_event = mock('started event')

--- a/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
@@ -1,0 +1,71 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','test_helper'))
+require 'new_relic/agent/instrumentation/mongodb_command_subscriber'
+
+class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest::Test
+  class Order; end
+
+  def setup
+    @started_event = mock('started event')
+    @started_event.stubs(:operation_id).returns(1)
+    @started_event.stubs(:command_name).returns('find')
+    @started_event.stubs(:database_name).returns('mongodb-test')
+    @started_event.stubs(:command).returns({ 'find' => 'users', 'filter' => { 'name' => 'test' }})
+
+    @succeeded_event = mock('succeeded event')
+    @succeeded_event.stubs(:operation_id).returns(1)
+    @succeeded_event.stubs(:duration).returns(2)
+
+    @subscriber = NewRelic::Agent::Instrumentation::MongodbCommandSubscriber.new
+
+    @stats_engine = NewRelic::Agent.instance.stats_engine
+    @stats_engine.clear_stats
+  end
+
+  def test_records_metrics_for_simple_find
+    simulate_query
+
+    metric_name = 'Datastore/statement/MongoDB/users/find'
+    assert_metrics_recorded(
+      metric_name => { :call_count => 1, :total_call_time => 2.0 }
+    )
+  end
+
+  def test_records_scoped_metrics
+    in_transaction('test_txn') { simulate_query }
+
+    metric_name = 'Datastore/statement/MongoDB/users/find'
+    assert_metrics_recorded(
+      [ metric_name, 'test_txn' ] => { :call_count => 1, :total_call_time => 2 }
+    )
+  end
+
+  def test_records_nothing_if_tracing_disabled
+    NewRelic::Agent.disable_all_tracing { simulate_query }
+    metric_name = 'Datastore/statement/MongoDB/users/find'
+    assert_metrics_not_recorded([ metric_name ])
+  end
+
+  def test_records_rollup_metrics
+    in_web_transaction { simulate_query }
+
+    assert_metrics_recorded(
+      'Datastore/operation/MongoDB/find' => { :call_count => 1, :total_call_time => 2 },
+      'Datastore/allWeb' => { :call_count => 1, :total_call_time => 2 },
+      'Datastore/all' => { :call_count => 1, :total_call_time => 2 }
+    )
+  end
+
+  def test_should_not_raise_due_to_an_exception_during_instrumentation_callback
+    @subscriber.stubs(:metrics).raises(StandardError)
+    simulate_query
+  end
+
+  def simulate_query
+    @subscriber.started(@started_event)
+    @subscriber.succeeded(@succeeded_event)
+  end
+end


### PR DESCRIPTION
This is for example only.

This is just a pull as a talking point on how I would envision the rpm gem would integration with the 2.1.0 Mongo Ruby driver once it is released. I have not written any tests yet, just wanted more to look at with the ongoing conversations we are having as to what this might look like.