### PR TITLE
Don't use a pager when running git log.  

### DIFF
--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -58,7 +58,7 @@ namespace :newrelic do
     current_revision = fetch(:current_revision)
 
     if scm == :git
-      log_command = "git log --no-color --pretty=format:'  * %an: %s' " +
+      log_command = "git --no-pager log --no-color --pretty=format:'  * %an: %s' " +
                     "--abbrev-commit --no-merges #{previous_revision}..#{current_revision}"
       `#{log_command}`
     end

--- a/lib/new_relic/recipes/capistrano_legacy.rb
+++ b/lib/new_relic/recipes/capistrano_legacy.rb
@@ -58,7 +58,7 @@ make_notify_task = Proc.new do
         from_revision = source.next_revision(current_revision)
 
         if scm == :git
-          log_command = "git log --no-color --pretty=format:'  * %an: %s' " +
+          log_command = "git --no-pager log --no-color --pretty=format:'  * %an: %s' " +
             "--abbrev-commit --no-merges #{previous_revision}..#{real_revision}"
         else
           log_command = "#{source.log(from_revision)}"


### PR DESCRIPTION
With many commits and no environment or config variable set, deploys will hang trying to report deployments and change sets to new relic.  To finish the deploy, you have to login to the server and kill the git process.  Then the deployment can complete.  