### PR TITLE
RUBY-1498: Event publishing with Mongo Ruby driver 2.1.0

### DIFF
--- a/lib/new_relic/agent/datastores/mongo/event_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/event_formatter.rb
@@ -21,7 +21,7 @@ module NewRelic
             result = {
               :operation => command_name,
               :database => database_name,
-              :collection => command.values.first
+              :collection => command.values[0]
             }
 
             command.each do |key, value|

--- a/lib/new_relic/agent/datastores/mongo/event_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/event_formatter.rb
@@ -19,9 +19,9 @@ module NewRelic
             return nil unless NewRelic::Agent.config[:'mongo.capture_queries']
 
             result = {
-              'operation' => command_name,
-              'database' => database_name,
-              'collection' => command.values.first
+              :operation => command_name,
+              :database => database_name,
+              :collection => command.values.first
             }
 
             command.each do |key, value|

--- a/lib/new_relic/agent/datastores/mongo/event_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/event_formatter.rb
@@ -21,7 +21,7 @@ module NewRelic
             result = {
               :operation => command_name,
               :database => database_name,
-              :collection => command.values[0]
+              :collection => command.values.first
             }
 
             command.each do |key, value|

--- a/lib/new_relic/agent/datastores/mongo/event_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/event_formatter.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+require 'new_relic/agent/datastores/mongo/obfuscator'
+
+module NewRelic
+  module Agent
+    module Datastores
+      module Mongo
+        module EventFormatter
+
+          # Keys that will get their values replaced with '?'.
+          OBFUSCATE_KEYS = [ 'filter', 'query' ].freeze
+
+          # Keys that will get completely removed from the statement.
+          BLACKLISTED_KEYS = [ 'deletes', 'documents', 'updates' ].freeze
+
+          def self.format(command_name, database_name, command)
+            return nil unless NewRelic::Agent.config[:'mongo.capture_queries']
+
+            result = {
+              'operation' => command_name,
+              'database' => database_name,
+              'collection' => command.values.first
+            }
+
+            command.each do |key, value|
+              next if BLACKLISTED_KEYS.include?(key)
+              if OBFUSCATE_KEYS.include?(key)
+                obfuscated = obfuscate(value)
+                result[key] = obfuscated if obfuscated
+              else
+                result[key] = value
+              end
+            end
+            result
+          end
+
+          def self.obfuscate(statement)
+            if NewRelic::Agent.config[:'mongo.obfuscate_queries']
+              statement = Obfuscator.obfuscate_statement(statement)
+            end
+            statement
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/datastores/mongo/obfuscator.rb
+++ b/lib/new_relic/agent/datastores/mongo/obfuscator.rb
@@ -10,7 +10,7 @@ module NewRelic
 
           WHITELIST = [:operation].freeze
 
-          def self.obfuscate_statement(source, whitelist=WHITELIST)
+          def self.obfuscate_statement(source, whitelist = WHITELIST)
             obfuscated = {}
             source.each do |key, value|
               if whitelist.include?(key)
@@ -23,7 +23,7 @@ module NewRelic
             obfuscated
           end
 
-          def self.obfuscate_value(value, whitelist)
+          def self.obfuscate_value(value, whitelist = WHITELIST)
             if value.is_a?(Hash)
               obfuscate_statement(value, whitelist)
             elsif value.is_a?(Array)

--- a/lib/new_relic/agent/datastores/mongo/statement_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/statement_formatter.rb
@@ -21,7 +21,8 @@ module NewRelic
           ]
 
           OBFUSCATE_KEYS = [
-            :selector
+            :selector,
+            :filter
           ]
 
           def self.format(statement, operation)

--- a/lib/new_relic/agent/datastores/mongo/statement_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/statement_formatter.rb
@@ -21,8 +21,7 @@ module NewRelic
           ]
 
           OBFUSCATE_KEYS = [
-            :selector,
-            :filter
+            :selector
           ]
 
           def self.format(statement, operation)

--- a/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
-require 'new_relic/agent/datastores/mongo/statement_formatter'
+require 'new_relic/agent/datastores/mongo/event_formatter'
 
 module NewRelic
   module Agent
@@ -62,9 +62,10 @@ module NewRelic
         end
 
         def generate_statement(event)
-          NewRelic::Agent::Datastores::Mongo::StatementFormatter.format(
-            { :database => event.database_name }.merge(event.command),
-            event.command_name
+          NewRelic::Agent::Datastores::Mongo::EventFormatter.format(
+            event.command_name,
+            event.database_name,
+            event.command
           )
         end
       end

--- a/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+require 'new_relic/agent/datastores/mongo/statement_formatter'
+
 module NewRelic
   module Agent
     module Instrumentation
@@ -30,7 +32,7 @@ module NewRelic
             )
 
             NewRelic::Agent.instance.transaction_sampler.notice_nosql_statement(
-              format_statement(started_event), event.duration
+              generate_statement(started_event), event.duration
             )
           rescue Exception => e
             log_notification_error('completed', e)
@@ -59,8 +61,11 @@ module NewRelic
           @operations ||= {}
         end
 
-        def format_statement(event)
-          "#{event.database_name}.#{event.command_name} #{event.command}"
+        def generate_statement(event)
+          NewRelic::Agent::Datastores::Mongo::StatementFormatter.format(
+            { :database => event.database_name }.merge(event.command),
+            event.command_name
+          )
         end
       end
     end

--- a/test/multiverse/suites/mongo/Envfile
+++ b/test/multiverse/suites/mongo/Envfile
@@ -1,11 +1,9 @@
 if RUBY_VERSION >= '1.9.3'
   gemfile <<-RB
-    gem 'mongo', '~>2.1.0.beta'
-    gem 'bson_ext', :platforms => :ruby
+    gem 'mongo', github: 'mongodb/mongo-ruby-driver'
   RB
   gemfile <<-RB
     gem 'mongo', '~>2.0.1'
-    gem 'bson_ext', :platforms => :ruby
   RB
 end
 

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -221,9 +221,12 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             end
 
             expected = {
-              :database   => @database_name,
-              :collection => @collection_name,
-              :operation  => :insert
+              'database'   => @database_name,
+              'collection' => @collection_name,
+              'insert' => @collection_name,
+              'operation'  => :insert,
+              'writeConcern' => { 'w' => 1 },
+              'ordered' => true
             }
 
             result = node.params[:statement]
@@ -241,7 +244,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal :insert, query[:operation]
+            assert_equal :insert, query['operation']
           end
 
           def test_noticed_nosql_includes_update_one_operation
@@ -255,7 +258,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal :update, query[:operation]
+            assert_equal :update, query['operation']
           end
 
           def test_noticed_nosql_includes_find_operation
@@ -269,7 +272,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal 'find', query[:operation]
+            assert_equal 'find', query['operation']
           end
 
           def test_noticed_nosql_does_not_contain_documents
@@ -290,7 +293,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             node = nil
 
             in_transaction do
-              @collection.delete_one({'password' => '$ecret'})
+              @collection.find({'password' => '$ecret'}).to_a
               node = find_last_transaction_node
             end
 
@@ -298,7 +301,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             refute statement.inspect.include?('$secret')
 
-            assert_equal '?', statement[:deletes].first['q']['password']
+            assert_equal '?', statement['filter']['password']
           end
 
           def test_web_requests_record_all_web_metric

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -221,10 +221,10 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             end
 
             expected = {
-              'database'   => @database_name,
-              'collection' => @collection_name,
+              :database   => @database_name,
+              :collection => @collection_name,
               'insert' => @collection_name,
-              'operation'  => :insert,
+              :operation  => :insert,
               'writeConcern' => { 'w' => 1 },
               'ordered' => true
             }
@@ -244,7 +244,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal :insert, query['operation']
+            assert_equal :insert, query[:operation]
           end
 
           def test_noticed_nosql_includes_update_one_operation
@@ -258,7 +258,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal :update, query['operation']
+            assert_equal :update, query[:operation]
           end
 
           def test_noticed_nosql_includes_find_operation
@@ -272,7 +272,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal 'find', query['operation']
+            assert_equal 'find', query[:operation]
           end
 
           def test_noticed_nosql_does_not_contain_documents

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -17,9 +17,8 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
           include TestHelpers::MongoMetricBuilder
 
           def setup
-            @client = Mongo::Client.new(["#{$mongo.host}:#{$mongo.port}"])
             @database_name = "multiverse"
-            @client.use(@database_name)
+            @client = Mongo::Client.new(["#{$mongo.host}:#{$mongo.port}"], :database => @database_name)
             @database = @client.database
 
             @collection_name = "tribbles-#{SecureRandom.hex(16)}"
@@ -39,7 +38,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
           def test_records_metrics_for_insert_one
             @collection.insert_one(@tribbles.first)
 
-            metrics = build_test_metrics(:insertOne)
+            metrics = build_test_metrics(:insert)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -48,7 +47,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
           def test_records_metrics_for_insert_many
             @collection.insert_many(@tribbles)
 
-            metrics = build_test_metrics(:insertMany)
+            metrics = build_test_metrics(:insert)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -60,7 +59,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.delete_one(@tribbles.first)
 
-            metrics = build_test_metrics(:deleteOne)
+            metrics = build_test_metrics(:delete)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -72,7 +71,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.delete_many(@tribbles.first)
 
-            metrics = build_test_metrics(:deleteMany)
+            metrics = build_test_metrics(:delete)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -84,7 +83,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.replace_one(@tribbles[0], @tribbles[1])
 
-            metrics = build_test_metrics(:replaceOne)
+            metrics = build_test_metrics(:update)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -96,7 +95,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.update_one(@tribbles[0], "$set" => @tribbles[1])
 
-            metrics = build_test_metrics(:updateOne)
+            metrics = build_test_metrics(:update)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -108,7 +107,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.update_many(@tribbles[0], "$set" => @tribbles[1])
 
-            metrics = build_test_metrics(:updateMany)
+            metrics = build_test_metrics(:update)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -132,7 +131,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.find_one_and_delete(@tribbles.first)
 
-            metrics = build_test_metrics(:findOneAndDelete)
+            metrics = build_test_metrics(:findandmodify)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -144,7 +143,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.find_one_and_replace(@tribbles[0], @tribbles[1])
 
-            metrics = build_test_metrics(:findOneAndReplace)
+            metrics = build_test_metrics(:findandmodify)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -156,7 +155,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             @collection.find_one_and_update(@tribbles[0], "$set" => @tribbles[1])
 
-            metrics = build_test_metrics(:findOneAndUpdate)
+            metrics = build_test_metrics(:findandmodify)
             expected = metrics_with_attributes(metrics)
 
             assert_metrics_recorded(expected)
@@ -270,7 +269,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             query = node.params[:statement]
 
-            assert_equal :find, query[:operation]
+            assert_equal 'find', query[:operation]
           end
 
           def test_noticed_nosql_does_not_contain_documents
@@ -299,7 +298,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             refute statement.inspect.include?('$secret')
 
-            assert_equal '?', statement[:selector]['password']
+            assert_equal '?', statement[:filter]['password']
           end
 
           def test_web_requests_record_all_web_metric

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -298,7 +298,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
             refute statement.inspect.include?('$secret')
 
-            assert_equal '?', statement[:filter]['password']
+            assert_equal '?', statement[:deletes].first['q']['password']
           end
 
           def test_web_requests_record_all_web_metric

--- a/test/new_relic/agent/datastores/mongo/event_formatter_test.rb
+++ b/test/new_relic/agent/datastores/mongo/event_formatter_test.rb
@@ -70,9 +70,9 @@ module NewRelic
 
           def test_event_formatter_obfuscates_by_default
             expected = {
-              "operation" => "find",
-              "database" => DATABASE,
-              "collection" => "tribbles",
+              :operation => :find,
+              :database => DATABASE,
+              :collection => "tribbles",
               "find" => "tribbles",
               "filter" => { "_id" => { "$gt" => "?" }, "name" => "?" },
               "sort" => { "_id" => 1 },
@@ -90,17 +90,17 @@ module NewRelic
               "snapshot" => false
             }
 
-            formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+            formatted = EventFormatter.format(:find, DATABASE, FIND_COMMAND)
             assert_equal expected, formatted
           end
 
           def test_event_formatter_raw_selectors
             with_config(:'mongo.obfuscate_queries' => false) do
-              formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+              formatted = EventFormatter.format(:find, DATABASE, FIND_COMMAND)
               expected = FIND_COMMAND.merge(
-                'operation' => 'find',
-                'database' => DATABASE,
-                'collection' => 'tribbles'
+                :operation => :find,
+                :database => DATABASE,
+                :collection => 'tribbles'
               )
               assert_equal expected, formatted
             end
@@ -108,40 +108,40 @@ module NewRelic
 
           def test_event_formatter_blacklists_inserts
             expected = {
-              "operation" => "insert",
-              "database" => DATABASE,
-              "collection" => "tribbles",
+              :operation => :insert,
+              :database => DATABASE,
+              :collection => "tribbles",
               "insert" => "tribbles",
               "ordered" => true
             }
 
-            formatted = EventFormatter.format('insert', DATABASE, INSERT_COMMAND)
+            formatted = EventFormatter.format(:insert, DATABASE, INSERT_COMMAND)
             assert_equal expected, formatted
           end
 
           def test_event_formatter_blacklists_updates
             expected = {
-              "operation" => "update",
-              "database" => DATABASE,
-              "collection" => "tribbles",
+              :operation => :update,
+              :database => DATABASE,
+              :collection => "tribbles",
               "update" => "tribbles",
               "ordered" => true
             }
 
-            formatted = EventFormatter.format('update', DATABASE, UPDATE_COMMAND)
+            formatted = EventFormatter.format(:update, DATABASE, UPDATE_COMMAND)
             assert_equal expected, formatted
           end
 
           def test_event_formatter_blacklists_deletes
             expected = {
-              "operation" => "delete",
-              "database" => DATABASE,
-              "collection" => "tribbles",
+              :operation => :delete,
+              :database => DATABASE,
+              :collection => "tribbles",
               "delete" => "tribbles",
               "ordered" => true
             }
 
-            formatted = EventFormatter.format('delete', DATABASE, DELETE_COMMAND)
+            formatted = EventFormatter.format(:delete, DATABASE, DELETE_COMMAND)
             assert_equal expected, formatted
           end
         end

--- a/test/new_relic/agent/datastores/mongo/event_formatter_test.rb
+++ b/test/new_relic/agent/datastores/mongo/event_formatter_test.rb
@@ -1,0 +1,151 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','test_helper'))
+require 'new_relic/agent/datastores/mongo/event_formatter'
+
+module NewRelic
+  module Agent
+    module Datastores
+      module Mongo
+        class EventFormatterTest < Minitest::Test
+
+          DATABASE = 'multiverse'.freeze
+
+          FIND_COMMAND = {
+            "find" => "tribbles",
+            "filter" => { "_id" => { "$gt" => 1 }, "name" => "joe" },
+            "sort" => { "_id" => 1 },
+            "limit" => 2,
+            "skip" => 2,
+            "comment" => "test",
+            "hint" => { "_id" => 1 },
+            "max" => { "_id" => 6 },
+            "maxScan" => 5000,
+            "maxTimeMS" => 6000,
+            "min" => { "_id" => 0 },
+            "readPreference" => { "mode" => "secondaryPreferred" },
+            "returnKey" => false,
+            "showRecordId" => false,
+            "snapshot" => false
+          }.freeze
+
+          INSERT_COMMAND = {
+            "insert" => "tribbles",
+            "ordered" => true,
+            "documents" => [{ :name => "test" }]
+          }.freeze
+
+          UPDATE_COMMAND = {
+            "update" => "tribbles",
+            "ordered" => true,
+            "updates" => [
+              {
+                :q => { :_id => { "$gt" => 1 }},
+                :u => { "$inc" => { :x => 1 }},
+                :multi => false,
+                :upsert => false
+              }
+            ]
+          }.freeze
+
+          DELETE_COMMAND = {
+            "delete" => "tribbles",
+            "ordered" => true,
+            "deletes" => [{ :q => { :_id => { "$gt" => 1 }}, :limit => 1 }]
+          }.freeze
+
+          def test_doesnt_modify_incoming_statement
+            formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+            refute_same FIND_COMMAND, formatted
+          end
+
+          def test_can_disable_statement_capturing_queries
+            with_config(:'mongo.capture_queries' => false) do
+              formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+              assert_nil formatted
+            end
+          end
+
+          def test_event_formatter_obfuscates_by_default
+            expected = {
+              "operation" => "find",
+              "database" => DATABASE,
+              "collection" => "tribbles",
+              "find" => "tribbles",
+              "filter" => { "_id" => { "$gt" => "?" }, "name" => "?" },
+              "sort" => { "_id" => 1 },
+              "limit" => 2,
+              "skip" => 2,
+              "comment" => "test",
+              "hint" => { "_id" => 1 },
+              "max" => { "_id" => 6 },
+              "maxScan" => 5000,
+              "maxTimeMS" => 6000,
+              "min" => { "_id" => 0 },
+              "readPreference" => { "mode" => "secondaryPreferred" },
+              "returnKey" => false,
+              "showRecordId" => false,
+              "snapshot" => false
+            }
+
+            formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+            assert_equal expected, formatted
+          end
+
+          def test_event_formatter_raw_selectors
+            with_config(:'mongo.obfuscate_queries' => false) do
+              formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+              expected = FIND_COMMAND.merge(
+                'operation' => 'find',
+                'database' => DATABASE,
+                'collection' => 'tribbles'
+              )
+              assert_equal expected, formatted
+            end
+          end
+
+          def test_event_formatter_blacklists_inserts
+            expected = {
+              "operation" => "insert",
+              "database" => DATABASE,
+              "collection" => "tribbles",
+              "insert" => "tribbles",
+              "ordered" => true
+            }
+
+            formatted = EventFormatter.format('insert', DATABASE, INSERT_COMMAND)
+            assert_equal expected, formatted
+          end
+
+          def test_event_formatter_blacklists_updates
+            expected = {
+              "operation" => "update",
+              "database" => DATABASE,
+              "collection" => "tribbles",
+              "update" => "tribbles",
+              "ordered" => true
+            }
+
+            formatted = EventFormatter.format('update', DATABASE, UPDATE_COMMAND)
+            assert_equal expected, formatted
+          end
+
+          def test_event_formatter_blacklists_deletes
+            expected = {
+              "operation" => "delete",
+              "database" => DATABASE,
+              "collection" => "tribbles",
+              "delete" => "tribbles",
+              "ordered" => true
+            }
+
+            formatted = EventFormatter.format('delete', DATABASE, DELETE_COMMAND)
+            assert_equal expected, formatted
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/datastores/mongo/event_formatter_test.rb
+++ b/test/new_relic/agent/datastores/mongo/event_formatter_test.rb
@@ -56,93 +56,96 @@ module NewRelic
             "deletes" => [{ :q => { :_id => { "$gt" => 1 }}, :limit => 1 }]
           }.freeze
 
-          def test_doesnt_modify_incoming_statement
-            formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
-            refute_same FIND_COMMAND, formatted
-          end
+          if RUBY_VERSION > "1.9.3"
 
-          def test_can_disable_statement_capturing_queries
-            with_config(:'mongo.capture_queries' => false) do
+            def test_doesnt_modify_incoming_statement
               formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
-              assert_nil formatted
+              refute_same FIND_COMMAND, formatted
             end
-          end
 
-          def test_event_formatter_obfuscates_by_default
-            expected = {
-              :operation => :find,
-              :database => DATABASE,
-              :collection => "tribbles",
-              "find" => "tribbles",
-              "filter" => { "_id" => { "$gt" => "?" }, "name" => "?" },
-              "sort" => { "_id" => 1 },
-              "limit" => 2,
-              "skip" => 2,
-              "comment" => "test",
-              "hint" => { "_id" => 1 },
-              "max" => { "_id" => 6 },
-              "maxScan" => 5000,
-              "maxTimeMS" => 6000,
-              "min" => { "_id" => 0 },
-              "readPreference" => { "mode" => "secondaryPreferred" },
-              "returnKey" => false,
-              "showRecordId" => false,
-              "snapshot" => false
-            }
+            def test_can_disable_statement_capturing_queries
+              with_config(:'mongo.capture_queries' => false) do
+                formatted = EventFormatter.format('find', DATABASE, FIND_COMMAND)
+                assert_nil formatted
+              end
+            end
 
-            formatted = EventFormatter.format(:find, DATABASE, FIND_COMMAND)
-            assert_equal expected, formatted
-          end
-
-          def test_event_formatter_raw_selectors
-            with_config(:'mongo.obfuscate_queries' => false) do
-              formatted = EventFormatter.format(:find, DATABASE, FIND_COMMAND)
-              expected = FIND_COMMAND.merge(
+            def test_event_formatter_obfuscates_by_default
+              expected = {
                 :operation => :find,
                 :database => DATABASE,
-                :collection => 'tribbles'
-              )
+                :collection => "tribbles",
+                "find" => "tribbles",
+                "filter" => { "_id" => { "$gt" => "?" }, "name" => "?" },
+                "sort" => { "_id" => 1 },
+                "limit" => 2,
+                "skip" => 2,
+                "comment" => "test",
+                "hint" => { "_id" => 1 },
+                "max" => { "_id" => 6 },
+                "maxScan" => 5000,
+                "maxTimeMS" => 6000,
+                "min" => { "_id" => 0 },
+                "readPreference" => { "mode" => "secondaryPreferred" },
+                "returnKey" => false,
+                "showRecordId" => false,
+                "snapshot" => false
+              }
+
+              formatted = EventFormatter.format(:find, DATABASE, FIND_COMMAND)
               assert_equal expected, formatted
             end
-          end
 
-          def test_event_formatter_blacklists_inserts
-            expected = {
-              :operation => :insert,
-              :database => DATABASE,
-              :collection => "tribbles",
-              "insert" => "tribbles",
-              "ordered" => true
-            }
+            def test_event_formatter_raw_selectors
+              with_config(:'mongo.obfuscate_queries' => false) do
+                formatted = EventFormatter.format(:find, DATABASE, FIND_COMMAND)
+                expected = FIND_COMMAND.merge(
+                  :operation => :find,
+                  :database => DATABASE,
+                  :collection => 'tribbles'
+                )
+                assert_equal expected, formatted
+              end
+            end
 
-            formatted = EventFormatter.format(:insert, DATABASE, INSERT_COMMAND)
-            assert_equal expected, formatted
-          end
+            def test_event_formatter_blacklists_inserts
+              expected = {
+                :operation => :insert,
+                :database => DATABASE,
+                :collection => "tribbles",
+                "insert" => "tribbles",
+                "ordered" => true
+              }
 
-          def test_event_formatter_blacklists_updates
-            expected = {
-              :operation => :update,
-              :database => DATABASE,
-              :collection => "tribbles",
-              "update" => "tribbles",
-              "ordered" => true
-            }
+              formatted = EventFormatter.format(:insert, DATABASE, INSERT_COMMAND)
+              assert_equal expected, formatted
+            end
 
-            formatted = EventFormatter.format(:update, DATABASE, UPDATE_COMMAND)
-            assert_equal expected, formatted
-          end
+            def test_event_formatter_blacklists_updates
+              expected = {
+                :operation => :update,
+                :database => DATABASE,
+                :collection => "tribbles",
+                "update" => "tribbles",
+                "ordered" => true
+              }
 
-          def test_event_formatter_blacklists_deletes
-            expected = {
-              :operation => :delete,
-              :database => DATABASE,
-              :collection => "tribbles",
-              "delete" => "tribbles",
-              "ordered" => true
-            }
+              formatted = EventFormatter.format(:update, DATABASE, UPDATE_COMMAND)
+              assert_equal expected, formatted
+            end
 
-            formatted = EventFormatter.format(:delete, DATABASE, DELETE_COMMAND)
-            assert_equal expected, formatted
+            def test_event_formatter_blacklists_deletes
+              expected = {
+                :operation => :delete,
+                :database => DATABASE,
+                :collection => "tribbles",
+                "delete" => "tribbles",
+                "ordered" => true
+              }
+
+              formatted = EventFormatter.format(:delete, DATABASE, DELETE_COMMAND)
+              assert_equal expected, formatted
+            end
           end
         end
       end

--- a/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
@@ -7,64 +7,66 @@ require 'new_relic/agent/instrumentation/mongodb_command_subscriber'
 
 class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest::Test
 
-  def setup
-    @started_event = mock('started event')
-    @started_event.stubs(:operation_id).returns(1)
-    @started_event.stubs(:command_name).returns('find')
-    @started_event.stubs(:database_name).returns('mongodb-test')
-    @started_event.stubs(:command).returns({ 'find' => 'users', 'filter' => { 'name' => 'test' }})
+  if RUBY_VERSION > "1.9.3"
+    def setup
+      @started_event = mock('started event')
+      @started_event.stubs(:operation_id).returns(1)
+      @started_event.stubs(:command_name).returns('find')
+      @started_event.stubs(:database_name).returns('mongodb-test')
+      @started_event.stubs(:command).returns({ 'find' => 'users', 'filter' => { 'name' => 'test' }})
 
-    @succeeded_event = mock('succeeded event')
-    @succeeded_event.stubs(:operation_id).returns(1)
-    @succeeded_event.stubs(:duration).returns(2)
+      @succeeded_event = mock('succeeded event')
+      @succeeded_event.stubs(:operation_id).returns(1)
+      @succeeded_event.stubs(:duration).returns(2)
 
-    @subscriber = NewRelic::Agent::Instrumentation::MongodbCommandSubscriber.new
+      @subscriber = NewRelic::Agent::Instrumentation::MongodbCommandSubscriber.new
 
-    @stats_engine = NewRelic::Agent.instance.stats_engine
-    @stats_engine.clear_stats
-  end
+      @stats_engine = NewRelic::Agent.instance.stats_engine
+      @stats_engine.clear_stats
+    end
 
-  def test_records_metrics_for_simple_find
-    simulate_query
+    def test_records_metrics_for_simple_find
+      simulate_query
 
-    metric_name = 'Datastore/statement/MongoDB/users/find'
-    assert_metrics_recorded(
-      metric_name => { :call_count => 1, :total_call_time => 2.0 }
-    )
-  end
+      metric_name = 'Datastore/statement/MongoDB/users/find'
+      assert_metrics_recorded(
+        metric_name => { :call_count => 1, :total_call_time => 2.0 }
+      )
+    end
 
-  def test_records_scoped_metrics
-    in_transaction('test_txn') { simulate_query }
+    def test_records_scoped_metrics
+      in_transaction('test_txn') { simulate_query }
 
-    metric_name = 'Datastore/statement/MongoDB/users/find'
-    assert_metrics_recorded(
-      [ metric_name, 'test_txn' ] => { :call_count => 1, :total_call_time => 2 }
-    )
-  end
+      metric_name = 'Datastore/statement/MongoDB/users/find'
+      assert_metrics_recorded(
+        [ metric_name, 'test_txn' ] => { :call_count => 1, :total_call_time => 2 }
+      )
+    end
 
-  def test_records_nothing_if_tracing_disabled
-    NewRelic::Agent.disable_all_tracing { simulate_query }
-    metric_name = 'Datastore/statement/MongoDB/users/find'
-    assert_metrics_not_recorded([ metric_name ])
-  end
+    def test_records_nothing_if_tracing_disabled
+      NewRelic::Agent.disable_all_tracing { simulate_query }
+      metric_name = 'Datastore/statement/MongoDB/users/find'
+      assert_metrics_not_recorded([ metric_name ])
+    end
 
-  def test_records_rollup_metrics
-    in_web_transaction { simulate_query }
+    def test_records_rollup_metrics
+      in_web_transaction { simulate_query }
 
-    assert_metrics_recorded(
-      'Datastore/operation/MongoDB/find' => { :call_count => 1, :total_call_time => 2 },
-      'Datastore/allWeb' => { :call_count => 1, :total_call_time => 2 },
-      'Datastore/all' => { :call_count => 1, :total_call_time => 2 }
-    )
-  end
+      assert_metrics_recorded(
+        'Datastore/operation/MongoDB/find' => { :call_count => 1, :total_call_time => 2 },
+        'Datastore/allWeb' => { :call_count => 1, :total_call_time => 2 },
+        'Datastore/all' => { :call_count => 1, :total_call_time => 2 }
+      )
+    end
 
-  def test_should_not_raise_due_to_an_exception_during_instrumentation_callback
-    @subscriber.stubs(:metrics).raises(StandardError)
-    simulate_query
-  end
+    def test_should_not_raise_due_to_an_exception_during_instrumentation_callback
+      @subscriber.stubs(:metrics).raises(StandardError)
+      simulate_query
+    end
 
-  def simulate_query
-    @subscriber.started(@started_event)
-    @subscriber.succeeded(@succeeded_event)
+    def simulate_query
+      @subscriber.started(@started_event)
+      @subscriber.succeeded(@succeeded_event)
+    end
   end
 end


### PR DESCRIPTION
@mwear This addresses most issues at stated here https://github.com/newrelic/rpm/pull/211#issuecomment-132009360

Responses to those questions:

1. `event.command.values.first` is guaranteed by our spec to always be the command name since `BSON::Documents` are ordered - it was an issue in the beta version of the Ruby driver, which is fixed in master and will be in the RC relase. I pointed the multiverse tests at master now instead of the beta.

2. The command that is issued will not always match the event name, as this is low level monitoring and we wanted to avoid any sort of method tracing in order to not break future the agent in future API changes to the driver. We also deemed it more important for a user to know exactly what was happening in the database... Ie a `find` can be a `find`, several `getmore` commands and a `killcursors` command... An `insert_many` can be split up into several `insert` commands, etc. This is the same across all of our drivers now in compliance with the spec.

3. I switched to use the statement formatter but there is one remaining failing test because it uses a whitelist approach instead of a blacklist one. Right now it's going to filter out the command name and collection name from the statements because they are not included in the list. This will include *all* commands sent to the database and any future additional commands. If you agree - I'd like to change this.