### PR TITLE
Fix an issue that was causing an ArgumentError "invalid byte sequence in UTF-8"

### DIFF
--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -266,6 +266,7 @@ module NewRelic
       EMPTY_STRING      = ''.freeze
 
       def parse_operation_from_query(sql)
+        sql = sql.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') # avoid ArgumentError "invalid byte sequence in UTF-8" if the SQL expression contains invalid UTF-8 characters
         sql = sql.gsub(SQL_COMMENT_REGEX, EMPTY_STRING)
         if sql =~ /(\w+)/
           op = $1.downcase


### PR DESCRIPTION
I added a BLOB column on one of my tables.
I use ruby `zlib` to compress some data into that BLOB column (with `Zlib::Deflate.deflate(string)`).
It happens that the resulting binary stream contains UTF-8 characters that use 4-bytes, which results on this error when the NewRelic agent tries to report the query metrics:

```
invalid byte sequence in UTF-8
/var/www/blocksworld/shared/bundle/ruby/2.2.0/gems/newrelic_rpm-3.13.0.299/lib/new_relic/agent/database.rb:269:in `gsub
/var/www/blocksworld/shared/bundle/ruby/2.2.0/gems/newrelic_rpm-3.13.0.299/lib/new_relic/agent/database.rb:269:in `parse_operation_from_query'
/var/www/blocksworld/shared/bundle/ruby/2.2.0/gems/newrelic_rpm-3.13.0.299/lib/new_relic/agent/datastores/metric_helper.rb:73:in `metrics_from_sql'
```

I found this article that suggested how to fix the issue:
https://robots.thoughtbot.com/fight-back-utf-8-invalid-byte-sequences

But that can only be fixed in the newrelic rpm code.
For now I will use my own fork, but please let me know if this pull request get's integrated so I can update my Gemfile to use the new version of rpm.

Thanks!