### PR TITLE
Rubinius at_exit handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,9 @@ rvm:
   - 2.2
   - jruby-19mode
   - jruby-18mode
+  - rbx-2.5.8
 
+matrix:
+  allow_failures:
+    - rvm: rbx-2.5.8
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ rvm:
   - 2.2
   - jruby-19mode
   - jruby-18mode
-  - rbx-2.5.8
+  - rbx-2
 
 matrix:
   allow_failures:
-    - rvm: rbx-2.5.8
-      
+    - rvm: rbx-2

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -370,7 +370,6 @@ module NewRelic
           def should_install_exit_handler?
             (
               Agent.config[:send_data_on_exit]                  &&
-              !NewRelic::LanguageSupport.using_engine?('rbx')   &&
               !NewRelic::LanguageSupport.using_engine?('jruby') &&
               !sinatra_classic_app?
             )

--- a/test/new_relic/agent/agent/start_test.rb
+++ b/test/new_relic/agent/agent/start_test.rb
@@ -89,7 +89,6 @@ class NewRelic::Agent::Agent::StartTest < Minitest::Test
   private :at_exit
 
   def test_install_exit_handler_positive
-    NewRelic::LanguageSupport.expects(:using_engine?).with('rbx').returns(false)
     NewRelic::LanguageSupport.expects(:using_engine?).with('jruby').returns(false)
     self.expects(:sinatra_classic_app?).returns(false)
     # we are overriding at_exit above, to immediately return, so we can
@@ -110,14 +109,10 @@ class NewRelic::Agent::Agent::StartTest < Minitest::Test
 
   def test_install_exit_handler_weird_ruby
     with_config(:send_data_one_exit => true) do
-      NewRelic::LanguageSupport.expects(:using_engine?).with('rbx').returns(false)
       NewRelic::LanguageSupport.expects(:using_engine?).with('jruby').returns(false)
       self.expects(:sinatra_classic_app?).returns(true)
       install_exit_handler
-      NewRelic::LanguageSupport.expects(:using_engine?).with('rbx').returns(false)
       NewRelic::LanguageSupport.expects(:using_engine?).with('jruby').returns(true)
-      install_exit_handler
-      NewRelic::LanguageSupport.expects(:using_engine?).with('rbx').returns(true)
       install_exit_handler
     end
   end


### PR DESCRIPTION
Rubinius can support the `at_exit` block used by `install_exit_handler`.  There is no need to prevent this behavior.