### PR TITLE
Add feature to enable Heroku Dyno name prefixing

### DIFF
--- a/lib/new_relic/agent/hostname.rb
+++ b/lib/new_relic/agent/hostname.rb
@@ -10,7 +10,11 @@ module NewRelic
         if dyno_name && ::NewRelic::Agent.config[:'heroku.use_dyno_names']
           matching_prefix = heroku_dyno_name_prefix(dyno_name)
           dyno_name = "#{matching_prefix}.*" if matching_prefix
-          dyno_name
+          dyno_prefix = ENV['DYNO_PREFIX']
+          if dyno_prefix
+            dyno_prefix + dyno_name
+          else
+            dyno_name
         else
           Socket.gethostname
         end


### PR DESCRIPTION
This feature is useful when having multiple Heroku deployments (i.e. app versions) reporting to the same New Relic App context.