### PR TITLE
Don't block running newrelic agent controller instrumentation on rails 1.2

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails/action_controller.rb
@@ -86,11 +86,11 @@ DependencyDetection.defer do
   end
 
   depends_on do
-    defined?(Rails) && Rails::VERSION::MAJOR.to_i == 2
+    defined?(Rails) && (1..2) === Rails::VERSION::MAJOR.to_i
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rails 2 Controller instrumentation'
+    ::NewRelic::Agent.logger.info 'Installing Rails 1.* - 2 Controller instrumentation'
   end
 
   executes do


### PR DESCRIPTION
The controller instrumentation still works on rails 1.2, even though it's not supported by Newrelic. Actually tested on a production rails 1.2 app.

The dependency check for controller instrumentation should do the same thing like the [view rendering instrumentation] (https://github.com/newrelic/rpm/blob/f1c5b4296531ef39f76fef90744c46b4d3398d47/lib/new_relic/agent/instrumentation/rails/action_controller.rb#L10-L14) here:  
     
       defined?(Rails::VERSION::STRING) && Rails::VERSION::STRING =~ /^(1\.|2\.0)/ # Rails 1.* - 2.0
     


