### PR TITLE
check for disabled_middleware_instrumentation first

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails_middleware.rb
+++ b/lib/new_relic/agent/instrumentation/rails_middleware.rb
@@ -8,11 +8,11 @@ DependencyDetection.defer do
   named :rails_middleware
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3
+    !::NewRelic::Agent.config[:disable_middleware_instrumentation]
   end
 
   depends_on do
-    !::NewRelic::Agent.config[:disable_middleware_instrumentation]
+    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3
   end
 
   executes do


### PR DESCRIPTION
When using a Mock/Stub/Fake ::Rails class that does not implement the VERSION this will fail unnecessarily even if the config file has disabled_middleware_instrumentation set to true. The re-ordering allows everything to work correctly.