### PR TITLE
Replace runtime defined? calls with const_defined?

### DIFF
--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -34,7 +34,9 @@ module NewRelic
         end
 
         def self.is_sinatra_app?(target)
-          defined?(::Sinatra::Base) && target.kind_of?(::Sinatra::Base)
+          Object.const_defined?(:Sinatra) &&
+            ::Sinatra.const_defined?(:Base) &&
+            target.kind_of?(::Sinatra::Base)
         end
 
         def self.for_class(target_class)

--- a/lib/new_relic/agent/parameter_filtering.rb
+++ b/lib/new_relic/agent/parameter_filtering.rb
@@ -14,9 +14,15 @@ module NewRelic
       end
 
       def filter_using_rails(env, params)
-        return params unless defined?(ActionDispatch::Http::ParameterFilter) && env.key?("action_dispatch.parameter_filter")
-        filters = env["action_dispatch.parameter_filter"]
-        ActionDispatch::Http::ParameterFilter.new(filters).filter(params)
+        if Object.const_defined?(:ActionDispatch) &&
+           ::ActionDispatch.const_defined?(:Http) &&
+           ::ActionDispatch::Http.const_defined?(:ParameterFilter) &&
+           env.key?("action_dispatch.parameter_filter")
+          filters = env["action_dispatch.parameter_filter"]
+          ActionDispatch::Http::ParameterFilter.new(filters).filter(params)
+        else
+          params
+        end
       end
 
       def filter_rack_file_data(env, params)


### PR DESCRIPTION
Using `defined?` in runtime is affecting app performance.
`ActiveSupport::Dependencies` which automatically hooks into const_missing
makes situation even worse.

```ruby
# jruby-9.0.3.0
require 'benchmark/ips'
# Uncomment for the second bench
# require 'active_support/dependencies'

Benchmark.ips do |x|
  x.config(warmup: 30, time: 20)
  x.report("const_defined?") do
    Object.const_defined?(:ActionDispatch) &&
      ::ActionDispatch.const_defined?(:Http) &&
      ::ActionDispatch::Http.const_defined?(:ParameterFilter)
  end
  x.report("defined?") { defined?(ActionDispatch::Http::ParameterFilter) }
  x.compare!
end
```

```
Comparison:
      const_defined?:  5621473.2 i/s
            defined?:    13207.5 i/s - 425.63x slower

Comparison (with ActiveSupport::Dependencies):
    const_defined?:  6011560.2 i/s
            defined?:     4278.5 i/s - 1405.06x slower
```

Real app flamegraph (https://github.com/SamSaffron/flamegraph) profiling results:

```
… activesupport-4.2.4/lib/active_support/dependencies.rb:184:in `const_missing'	(40 samples - 51.28%)
… newrelic_rpm-3.14.0.305/lib/new_relic/agent/parameter_filtering.rb:17:in `filter_using_rails'	(12 samples - 15.38%)
````

````
… activesupport-4.2.4/lib/active_support/dependencies.rb:184:in `const_missing'	(40 samples - 51.28%)
… newrelic_rpm-3.14.0.305/lib/new_relic/agent/instrumentation/middleware_proxy.rb:37:in `is_sinatra_app?'	(27 samples - 34.62%)
```