### PR TITLE
Coerce integers attributes into strings

### DIFF
--- a/lib/new_relic/coerce.rb
+++ b/lib/new_relic/coerce.rb
@@ -46,8 +46,10 @@ module NewRelic
 
     def scalar(val)
       case val
-      when String, Integer, TrueClass, FalseClass, NilClass
+      when String, TrueClass, FalseClass, NilClass
         val
+      when Integer
+        val.to_s
       when Float
         if val.finite?
           val

--- a/test/new_relic/agent/attribute_processing_test.rb
+++ b/test/new_relic/agent/attribute_processing_test.rb
@@ -100,7 +100,7 @@ class AttributeProcessingTest < Minitest::Test
     assert_equal(
       {
         'foo'    => 1.0,
-        'bar'    => 2,
+        'bar'    => "2",
         'bang'   => 'woot',
         'ok'     => 'dokey',
         'yes'    => '[]',

--- a/test/new_relic/agent/error_event_aggregator_test.rb
+++ b/test/new_relic/agent/error_event_aggregator_test.rb
@@ -99,7 +99,7 @@ module NewRelic
 
         _, custom_attrs, _ = last_error_event
 
-        assert_equal attrs, custom_attrs
+        assert_equal({"user" => "Wes Mantooth", "channel" => "9"}, custom_attrs)
       end
 
       def test_includes_agent_attributes

--- a/test/new_relic/agent/instrumentation/task_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/task_instrumentation_test.rb
@@ -137,7 +137,7 @@ class NewRelic::Agent::Instrumentation::TaskInstrumentationTest < Minitest::Test
 
     refute_nil(cpu_time, "cpu time nil: \n#{sample}")
     assert(cpu_time >= 0, "cpu time: #{cpu_time},\n#{sample}")
-    assert_equal(10, attributes_for(sample, :agent)['request.parameters.level'])
+    assert_equal('10', attributes_for(sample, :agent)['request.parameters.level'])
   end
 
   def test_abort_transaction

--- a/test/new_relic/agent/transaction/attributes_test.rb
+++ b/test/new_relic/agent/transaction/attributes_test.rb
@@ -212,7 +212,7 @@ class AttributesTest < Minitest::Test
     attributes = create_attributes
     attributes.merge_custom_attributes(:key => 42)
 
-    assert_equal 42, custom_attributes(attributes)["key"]
+    assert_equal "42", custom_attributes(attributes)["key"]
   end
 
   def test_limits_attribute_count

--- a/test/new_relic/agent/transaction_event_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_event_aggregator_test.rb
@@ -51,8 +51,8 @@ class NewRelic::Agent::TransactionEventAggregatorTest < Minitest::Test
       generate_request('whatever')
 
       result = captured_transaction_event[CUSTOM_ATTRIBUTES_INDEX]
-      assert_equal 2, result['bing']
-      assert_equal 3, result['1']
+      assert_equal '2', result['bing']
+      assert_equal '3', result['1']
     end
   end
 
@@ -84,7 +84,7 @@ class NewRelic::Agent::TransactionEventAggregatorTest < Minitest::Test
       generate_request('whatever')
 
       custom_attrs = captured_transaction_event[CUSTOM_ATTRIBUTES_INDEX]
-      assert_equal 2, custom_attrs['bing']
+      assert_equal '2', custom_attrs['bing']
     end
   end
 

--- a/test/new_relic/coerce_test.rb
+++ b/test/new_relic/coerce_test.rb
@@ -89,6 +89,10 @@ class CoerceTest < Minitest::Test
     string(Unstringable.new, "HERE")
   end
 
+  def test_scalar_integer
+    assert_equal "1234", scalar(1234)
+  end
+
   class Unstringable
     undef :to_s
   end

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -202,7 +202,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
       error = NewRelic::NoticedError.new(@path, Exception.new("O_o"))
       error.attributes = attributes
 
-      assert_equal custom_attrs, error.custom_attributes
+      assert_equal({"name" => "Ron Burgundy", "channel" => "4"}, error.custom_attributes)
     end
   end
 


### PR DESCRIPTION
Avoids imprecise float conversion when tracking bigint values. Without conversion to strings, the values are coerced in a fashion that modifies the value of the integer.

For instance, with a source value of 129051960153211241, the value as seen in NewRelic is changed to 129051960153211250.