### PR TITLE
Removing the link to the app role

### DIFF
--- a/lib/new_relic/recipes/capistrano_legacy.rb
+++ b/lib/new_relic/recipes/capistrano_legacy.rb
@@ -8,7 +8,7 @@ make_notify_task = Proc.new do
 
     # on all deployments, notify New Relic
     desc "Record a deployment in New Relic (newrelic.com)"
-    task :notice_deployment, :roles => :app, :except => {:no_release => true } do
+    task :notice_deployment do
       rails_env = fetch(:newrelic_rails_env, fetch(:rails_env, "production"))
 
       require 'new_relic/cli/command'


### PR DESCRIPTION
Deployments that don't use the :app role are failing because of the fact that this job is fixed to the :app role. Why is there even a link to the app role? What does it have to do with a role? We just need a single deployment message to NewRelic.