### PR TITLE
Fixes Grape metrics with a default extension.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes #
 
+## Next ##
+
+  * Fixes Grape metrics with a default extension
+
+  Starting with Grape 0.12.0 an API with a single format no longer declares methods with (.:format),
+  but with, for example, (.json). NewRelic instrumentation failed to strip the extension from the
+  transaction name.
+
 ## v3.14.2 ##
 
   * Improved transaction names for Sinatra

--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -11,7 +11,7 @@ module NewRelic
         extend self
 
         API_ENDPOINT   = 'api.endpoint'.freeze
-        FORMAT_REGEX   = /\(\/?\.:format\)/.freeze
+        FORMAT_REGEX   = /\(\/?\.[\:\w]*\)/.freeze # either :format (< 0.12.0) or .ext (>= 0.12.0)
         VERSION_REGEX  = /:version(\/|$)/.freeze
         EMPTY_STRING   = ''.freeze
         MIN_VERSION    = VersionNumber.new("0.2.0")

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -2,7 +2,7 @@ suite_condition("Grape is only supported for versions >= 1.9.3") do
   RUBY_VERSION >= '1.9.3'
 end
 
-versions = %w(0.9.0 0.8.0 0.7.0 0.6.1 0.5.0 0.4.1 0.3.2 0.2.6 0.2.0 0.1.5)
+versions = %w(0.14.0 0.13.0 0.12.0 0.11.0 0.10.0 0.9.0 0.8.0 0.7.0 0.6.1 0.5.0 0.4.1 0.3.2 0.2.6 0.2.0 0.1.5)
 
 versions.each do |version|
   gemfile <<-RB


### PR DESCRIPTION
Starting with Grape 0.12.0 an API with a single format no longer declares methods with (.:format), but with, for example, (.json). NewRelic instrumentation failed to strip the extension from the transaction name.

Added newer grape versions to the multiverse tests.
