### PR TITLE
newrelic.yml: Avoid trailing whitespace in comment

### DIFF
--- a/newrelic.yml
+++ b/newrelic.yml
@@ -4,7 +4,7 @@
 # overhead.  For more information, visit www.newrelic.com.
 #
 # Generated <%= Time.now.strftime('%B %d, %Y') %><%= ", for version #{@agent_version}" if @agent_version %>
-# <%= "\n# #{generated_for_user}\n#" if generated_for_user %>
+#<%= "\n# #{generated_for_user}\n#" if generated_for_user %>
 # For full documentation of agent configuration options, please refer to
 # https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
 


### PR DESCRIPTION
Running `newrelic` to generate a configuration from the template, a
trailing whitespace would be introduced. Remove it in the template, so
that certain coding style utilities don’t complain.