### PR TITLE
Fix delayed jobs sampler query in AR3

### DIFF
--- a/lib/new_relic/agent/samplers/delayed_job_sampler.rb
+++ b/lib/new_relic/agent/samplers/delayed_job_sampler.rb
@@ -51,7 +51,7 @@ module NewRelic
 
         def count(query)
           if ::ActiveRecord::VERSION::MAJOR.to_i < 4
-            ::Delayed::Job.count(query)
+            ::Delayed::Job.count(conditions: query)
           else
             ::Delayed::Job.where(query).count
           end

--- a/lib/new_relic/agent/samplers/delayed_job_sampler.rb
+++ b/lib/new_relic/agent/samplers/delayed_job_sampler.rb
@@ -51,7 +51,7 @@ module NewRelic
 
         def count(query)
           if ::ActiveRecord::VERSION::MAJOR.to_i < 4
-            ::Delayed::Job.count(conditions: query)
+            ::Delayed::Job.count(:conditions => query)
           else
             ::Delayed::Job.where(query).count
           end


### PR DESCRIPTION
This fixes a regression introduced by 1e457bb7

At least in postgresql `count(false)` returns 1, so the query that was
generated was always counting everything in the `delayed_jobs` table and
not just the non-null records as it is meant to do.