### PR TITLE
Fix incompatibility issue with rails5.0.0beta3

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -82,7 +82,7 @@ module NewRelic
             when defined?(::NewRelic::TEST) then :test
             when defined?(::Merb) && defined?(::Merb::Plugins) then :merb
             when defined?(::Rails::VERSION)
-              case Rails::VERSION::MAJOR
+              case Rails::VERSION::MAJOR.to_i
               when 0..2
                 :rails
               when 3


### PR DESCRIPTION
I got "detected unsupported rails version 5.0.0.beta3" when running rails. It appears that `Rails::VERSION::MAJOR` returns a type string, rather that integer - not sure if this changed from earlier versions, in which case it's probably a bug in rails. Nevertheless, to get things working, I made this fix.