### PR TITLE
Add transaction support for padrino 0.13

### DIFF
--- a/lib/new_relic/agent/instrumentation/padrino.rb
+++ b/lib/new_relic/agent/instrumentation/padrino.rb
@@ -27,6 +27,42 @@ DependencyDetection.defer do
 
       alias dispatch_without_newrelic dispatch!
       alias dispatch! dispatch_with_newrelic
+
+      # Padrino 0.13 mustermann routing
+      if private_method_defined?(:invoke_route)
+        include NewRelic::Agent::Instrumentation::Padrino
+
+        alias invoke_route_without_newrelic invoke_route
+        alias invoke_route invoke_route_with_newrelic
+      end
+    end
+  end
+end
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      module Padrino
+        def invoke_route_with_newrelic(*args, &block)
+          begin
+            env["newrelic.last_route"] = args[0].original_path
+          rescue => e
+            ::NewRelic::Agent.logger.debug("Failed determining last route in Padrino", e)
+          end
+
+          begin
+            txn_name = ::NewRelic::Agent::Instrumentation::Sinatra::TransactionNamer.transaction_name_for_route(env, request)
+            unless txn_name.nil?
+              ::NewRelic::Agent::Transaction.set_default_transaction_name(
+                "#{self.class.name}/#{txn_name}", :sinatra)
+            end
+          rescue => e
+            ::NewRelic::Agent.logger.debug("Failed during invoke_route to set transaction name", e)
+          end
+
+          invoke_route_without_newrelic(*args, &block)
+        end
+      end
     end
   end
 end

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,3 +1,10 @@
+gemfile <<-RB
+  gem 'activesupport', '~> 3'
+  gem 'padrino', '~> 0.13.0'
+  gem 'rack-test', :require => 'rack/test'
+  gem 'i18n', '< 0.7' if RUBY_VERSION < '1.9.3' # i18n >= 0.7.0 only works on Ruby 1.9.3 and newer
+RB
+
 if RUBY_VERSION > '1.8.7' # padrino-core 0.11.0 requires http_router 0.11.0 which has syntax errors in 1.8.7.
 gemfile <<-RB
   gem 'activesupport', '~> 3'

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,9 +1,10 @@
+if RUBY_VERSION >= '1.9.3' # padrino v0.12.0 dropped support for ruby 1.8.7 and requres ruby 1.9.3 or greater
 gemfile <<-RB
   gem 'activesupport', '~> 3'
   gem 'padrino', '~> 0.13.0'
   gem 'rack-test', :require => 'rack/test'
-  gem 'i18n', '< 0.7' if RUBY_VERSION < '1.9.3' # i18n >= 0.7.0 only works on Ruby 1.9.3 and newer
 RB
+end
 
 if RUBY_VERSION > '1.8.7' # padrino-core 0.11.0 requires http_router 0.11.0 which has syntax errors in 1.8.7.
 gemfile <<-RB


### PR DESCRIPTION
Padrino 0.13 started to use mustermann as routing engine. Therefore, the method `route_eval` might not get called anymore and the `route_obj` is added later to the `request`.
This instrumentation hooks into the new `invoke_route` method which came with padrino 0.13.

This addresses padrino/padrino-framework#2002 and https://discuss.newrelic.com/t/missing-route-details-in-transaction-log/34989