### PR TITLE
Restore older DataMapper support after password obfuscation fix.

### DIFF
--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -147,7 +147,8 @@ module NewRelic
                 strategy = NewRelic::Agent::Database.record_sql_method(:slow_sql)
                 case strategy
                 when :obfuscated
-                  statement = NewRelic::Agent::Database::Statement.new(e.query, :adapter => self.options[:adapter])
+                  adapter_name = self.respond_to?(:options) ? self.options[:adapter] : self.repository.adapter.uri.scheme
+                  statement = NewRelic::Agent::Database::Statement.new(e.query, :adapter => adapter_name)
                   obfuscated_sql = NewRelic::Agent::Database.obfuscate_sql(statement)
                   e.instance_variable_set(:@query, obfuscated_sql)
                 when :off


### PR DESCRIPTION
DataMapper versions below v0.10.0 do not implement the #options accessor. Instead, the adapter name (scheme) has to be fetched from the URI object. 

Fetching the URI this deeply nested is needed to support both DataObjectsAdapter and DataMapper::Collection/Model instances.