### PR TITLE
Fix: deprecation warning in Grape 0.16.x.

### DIFF
--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -28,15 +28,29 @@ module NewRelic
           Transaction.set_default_transaction_name(txn_name, :grape, node_name)
         end
 
-        def name_for_transaction(route, class_name)
-          action_name = route.route_path.sub(FORMAT_REGEX, EMPTY_STRING)
-          method_name = route.route_method
+        if defined?(Grape::VERSION) && VersionNumber.new(::Grape::VERSION) >= VersionNumber.new("0.16.0")
+          def name_for_transaction(route, class_name)
+            action_name = route.path.sub(FORMAT_REGEX, EMPTY_STRING)
+            method_name = route.request_method
 
-          if route.route_version
-            action_name = action_name.sub(VERSION_REGEX, EMPTY_STRING)
-            "#{class_name}-#{route.route_version}#{action_name} (#{method_name})"
-          else
-            "#{class_name}#{action_name} (#{method_name})"
+            if route.version
+              action_name = action_name.sub(VERSION_REGEX, EMPTY_STRING)
+              "#{class_name}-#{route.version}#{action_name} (#{method_name})"
+            else
+              "#{class_name}#{action_name} (#{method_name})"
+            end
+          end
+        else
+          def name_for_transaction(route, class_name)
+            action_name = route.route_path.sub(FORMAT_REGEX, EMPTY_STRING)
+            method_name = route.route_method
+
+            if route.route_version
+              action_name = action_name.sub(VERSION_REGEX, EMPTY_STRING)
+              "#{class_name}-#{route.route_version}#{action_name} (#{method_name})"
+            else
+              "#{class_name}#{action_name} (#{method_name})"
+            end
           end
         end
 

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -2,7 +2,7 @@ suite_condition("Grape is only supported for versions >= 1.9.3") do
   RUBY_VERSION >= '1.9.3'
 end
 
-versions = %w(0.14.0 0.13.0 0.12.0 0.11.0 0.10.0 0.9.0 0.8.0 0.7.0 0.6.1 0.5.0 0.4.1 0.3.2 0.2.6 0.2.0 0.1.5)
+versions = %w(0.16.1 0.15.0 0.14.0 0.13.0 0.12.0 0.11.0 0.10.0 0.9.0 0.8.0 0.7.0 0.6.1 0.5.0 0.4.1 0.3.2 0.2.6 0.2.0 0.1.5)
 
 versions.each do |version|
   gemfile <<-RB


### PR DESCRIPTION
In Grape 0.16.x `route_` methods are no longer prefixed. See https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#replace-rack-mount-with-new-router. 