### PR TITLE
Use the new Grape helpers to avoid the deprecation warnings

### DIFF
--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -29,12 +29,12 @@ module NewRelic
         end
 
         def name_for_transaction(route, class_name)
-          action_name = route.route_path.sub(FORMAT_REGEX, EMPTY_STRING)
-          method_name = route.route_method
+          action_name = route.path.sub(FORMAT_REGEX, EMPTY_STRING)
+          method_name = route.request_method
 
-          if route.route_version
+          if route.version
             action_name = action_name.sub(VERSION_REGEX, EMPTY_STRING)
-            "#{class_name}-#{route.route_version}#{action_name} (#{method_name})"
+            "#{class_name}-#{route.version}#{action_name} (#{method_name})"
           else
             "#{class_name}#{action_name} (#{method_name})"
           end


### PR DESCRIPTION
[`route_xxx` methods have been deprecated in version 0.15.1 of Grape](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md) and are now throwing deprecation warnings.

### Changes

* Use `path` instead of `route_path`
* Use `request_method` instead of `route_method`
* Use `version` instead of `route_version`

