### PR TITLE
Fix warnings about instance variables not initialized

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -71,6 +71,8 @@ module NewRelic
         @connect_state      = :pending
         @connect_attempts   = 0
         @environment_report = nil
+        @waited_on_connect  = nil
+        @connected_pid      = nil
 
         @wait_on_connect_reader, @wait_on_connect_writer = IO.pipe
 
@@ -472,7 +474,7 @@ module NewRelic
           end
 
           def in_resque_child_process?
-            @service.is_a?(NewRelic::Agent::PipeService)
+            defined?(@service) && @service.is_a?(NewRelic::Agent::PipeService)
           end
 
           # Sanity-check the agent configuration and start the agent,

--- a/lib/new_relic/agent/audit_logger.rb
+++ b/lib/new_relic/agent/audit_logger.rb
@@ -13,6 +13,7 @@ module NewRelic
         @enabled = NewRelic::Agent.config[:'audit_log.enabled']
         @endpoints = NewRelic::Agent.config[:'audit_log.endpoints']
         @encoder = NewRelic::Agent::NewRelicService::Encoders::Identity
+        @log = nil
       end
 
       attr_writer :enabled

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -99,7 +99,7 @@ module NewRelic
           end
 
           def newrelic_read_attr(attr_name) # :nodoc:
-            instance_variable_get(attr_name)
+            instance_variable_get(attr_name) if instance_variable_defined?(attr_name)
           end
 
           # Add transaction tracing to the given method.  This will treat

--- a/lib/new_relic/agent/instrumentation/rack.rb
+++ b/lib/new_relic/agent/instrumentation/rack.rb
@@ -79,7 +79,7 @@ module NewRelic
         end
 
         def self.check_for_late_instrumentation(app)
-          return if @checked_for_late_instrumentation
+          return if @checked_for_late_instrumentation ||= nil
           @checked_for_late_instrumentation = true
           if middleware_instrumentation_enabled?
             if ::NewRelic::Agent::Instrumentation::MiddlewareProxy.needs_wrapping?(app)

--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -139,6 +139,7 @@ module NewRelic
         attr_accessor :pipes, :timeout, :select_timeout
 
         def initialize
+          @started = nil
           @pipes = {}
           @pipes_lock = Mutex.new
 

--- a/lib/new_relic/agent/sampler.rb
+++ b/lib/new_relic/agent/sampler.rb
@@ -24,7 +24,7 @@ module NewRelic
       end
 
       def self.name
-        @name
+        @name ||= nil
       end
 
       def self.inherited(subclass)
@@ -37,7 +37,7 @@ module NewRelic
       end
 
       def self.enabled?
-        if @name
+        if self.name
           config_key = "disable_#{@name}_sampler"
           !(Agent.config[config_key])
         else

--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -33,6 +33,8 @@ module NewRelic
             @sampler = ShellPS.new("ps -o rss")
           elsif platform =~ /solaris/
             @sampler = ShellPS.new("/usr/bin/ps -o rss -p")
+          else
+            @sampler = nil
           end
 
           raise Unsupported, "Unsupported platform for getting memory: #{platform}" if @sampler.nil?

--- a/lib/new_relic/agent/threading/backtrace_service.rb
+++ b/lib/new_relic/agent/threading/backtrace_service.rb
@@ -26,6 +26,7 @@ module NewRelic
         def initialize(event_listener=nil)
           @profiles = {}
           @buffer = {}
+          @last_poll = nil
 
           # synchronizes access to @profiles and @buffer above
           @lock = Mutex.new

--- a/lib/new_relic/agent/transaction/attributes.rb
+++ b/lib/new_relic/agent/transaction/attributes.rb
@@ -25,6 +25,7 @@ module NewRelic
 
           @custom_destinations = {}
           @agent_destinations = {}
+          @already_warned_count_limit = nil
         end
 
         def add_agent_attribute(key, value, default_destinations)

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -19,6 +19,7 @@ module NewRelic
         def initialize(timestamp, metric_name)
           @entry_timestamp = timestamp
           @metric_name     = metric_name || UNKNOWN_NODE_NAME
+          @exit_timestamp  = nil
           @called_nodes    = nil
         end
 
@@ -42,7 +43,7 @@ module NewRelic
           [ NewRelic::Helper.time_to_millis(@entry_timestamp),
             NewRelic::Helper.time_to_millis(@exit_timestamp),
             NewRelic::Coerce.string(@metric_name),
-            (@params || {}) ] +
+            (@params ||= {}) ] +
             [ (@called_nodes ? @called_nodes.map{|s| s.to_array} : []) ]
         end
 

--- a/lib/new_relic/agent/transaction_state.rb
+++ b/lib/new_relic/agent/transaction_state.rb
@@ -38,6 +38,7 @@ module NewRelic
         @traced_method_stack = TracedMethodStack.new
         @current_transaction = nil
         @record_tt = nil
+        @record_sql = nil
       end
 
       # This starts the timer for the transaction.

--- a/lib/new_relic/agent/worker_loop.rb
+++ b/lib/new_relic/agent/worker_loop.rb
@@ -20,10 +20,11 @@ module NewRelic
         @should_run = true
         @next_invocation_time = Time.now
         @period = 60.0
-        @duration = opts[:duration] if opts[:duration]
-        @limit = opts[:limit] if opts[:limit]
+        @duration = opts[:duration]
+        @limit = opts[:limit]
         @iterations = 0
         @propagate_errors = opts.fetch(:propagate_errors, false)
+        @deadline = nil
       end
 
       # Reset state that is changed by running the worker loop

--- a/lib/new_relic/cli/commands/deployments.rb
+++ b/lib/new_relic/cli/commands/deployments.rb
@@ -33,6 +33,7 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
     super(command_line_args)
     @description ||= @leftover && @leftover.join(" ")
     @user ||= ENV['USER']
+    @environment ||= nil
     control.env = @environment if @environment
 
     load_yaml_from_env(control.env)
@@ -69,7 +70,7 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
             :description => @description,
             :user => @user,
             :revision => @revision,
-            :changelog => @changelog
+            :changelog => @changelog ||= nil
       }.each do |k, v|
         create_params["deployment[#{k}]"] = v unless v.nil? || v == ''
       end
@@ -119,7 +120,7 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
                "currently: #{control.env}") { | e | @environment = e }
       o.on("-u", "--user=USER", String,
              "Specify the user deploying, for information only",
-             "Default: #{@user || '<none>'}") { | u | @user = u }
+             "Default: #{defined?(@user) && @user || '<none>'}") { | u | @user = u }
       o.on("-r", "--revision=REV", String,
              "Specify the revision being deployed") { | r | @revision = r }
       o.on("-l", "--license-key=KEY", String,

--- a/lib/new_relic/cli/commands/install.rb
+++ b/lib/new_relic/cli/commands/install.rb
@@ -23,7 +23,7 @@ class NewRelic::Cli::Install < NewRelic::Cli::Command
   attr_reader :dest_dir, :license_key, :generated_for_user, :quiet, :src_file, :app_name
   def initialize command_line_args={}
     super command_line_args
-    if !@dest_dir
+    if !(@dest_dir ||= nil)
       # Install a newrelic.yml file into the local config directory.
       if File.directory? "config"
         @dest_dir = "config"

--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -69,7 +69,7 @@ module NewRelic
         end
 
         def install_agent_hooks(config)
-          return if @agent_hooks_installed
+          return if @agent_hooks_installed ||= nil
           @agent_hooks_installed = true
           return if config.nil? || !config.respond_to?(:middleware)
           begin
@@ -83,7 +83,7 @@ module NewRelic
         end
 
         def install_browser_monitoring(config)
-          return if @browser_monitoring_installed
+          return if @browser_monitoring_installed ||= nil
           @browser_monitoring_installed = true
           return if config.nil? || !config.respond_to?(:middleware) || !Agent.config[:'browser_monitoring.auto_instrument']
           begin
@@ -96,7 +96,7 @@ module NewRelic
         end
 
         def install_developer_mode(rails_config)
-          return if @installed
+          return if @installed ||= nil
           @installed = true
           if rails_config && rails_config.respond_to?(:middleware)
             begin

--- a/lib/new_relic/metric_data.rb
+++ b/lib/new_relic/metric_data.rb
@@ -12,6 +12,7 @@ module NewRelic
     attr_accessor :stats
 
     def initialize(metric_spec, stats)
+      @original_spec = nil
       @metric_spec = metric_spec
       self.stats = stats
     end

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -55,6 +55,8 @@ class NewRelic::NoticedError
       @message = STRIPPED_EXCEPTION_REPLACEMENT_MESSAGE
     end
 
+    @attributes_from_notice_error = nil
+    @attributes = nil
     @timestamp = timestamp
   end
 

--- a/ui/helpers/developer_mode_helper.rb
+++ b/ui/helpers/developer_mode_helper.rb
@@ -17,6 +17,7 @@ module NewRelic::DeveloperModeHelper
   end
 
   def trace_row_display_limit_reached
+    @detail_node_count ||= nil
    (!@detail_node_count.nil? && @detail_node_count > trace_row_display_limit) || sql_segments(@sample).length > trace_row_display_limit
   end
 

--- a/ui/helpers/google_pie_chart.rb
+++ b/ui/helpers/google_pie_chart.rb
@@ -11,6 +11,7 @@ class GooglePieChart
   def initialize
     # an array of [label, value]
     @data = []
+    @max = nil
     self.width = 300
     self.height = 200
   end


### PR DESCRIPTION
Running tests with "RUBYOPT=-w" we can see many warning messages. I've tried resolve them without breaking anything.