### PR TITLE
Allow oracle_enhanced adapter to obfuscate properly

### DIFF
--- a/lib/new_relic/agent/database/obfuscation_helpers.rb
+++ b/lib/new_relic/agent/database/obfuscation_helpers.rb
@@ -44,7 +44,8 @@ module NewRelic
           :postgres => /'|\/\*|\*\/|\$(?!\?)/,
           :sqlite => /'|\/\*|\*\//,
           :cassandra => /'|\/\*|\*\//,
-          :oracle => /'|\/\*|\*\//
+          :oracle => /'|\/\*|\*\//,
+          :oracle_enhanced => /'|\/\*|\*\//
         }
 
         PLACEHOLDER = '?'.freeze
@@ -75,7 +76,7 @@ module NewRelic
             regex = POSTGRES_COMPONENTS_REGEX
           when :sqlite
             regex = SQLITE_COMPONENTS_REGEX
-          when :oracle
+          when :oracle, :oracle_enhanced
             regex = ORACLE_COMPONENTS_REGEX
           when :cassandra
             regex = CASSANDRA_COMPONENTS_REGEX


### PR DESCRIPTION
The oracle_enhanced ActiveRecord driver is a popular choice among those using Oracle with Rails, and is currently [mapped to the product name 'Oracle'](https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/active_record_helper.rb#L201) in this project. However, the only adapter name supported for obfuscation with Oracle is `:oracle`. This PR allows the `:oracle_enhanced` adapter to use the oracle obfuscator path, turning query dumps like this:

```SQL
"SELECT  ?.* FROM ?  WHERE ?.? = ? AND ROWNUM <= ?"
```

into this:

```SQL
"SELECT  \"MYTABLE\".* FROM \"MYTABLE\"  WHERE \"MYTABLE\".\"MYCOLUMN\" = ? AND ROWNUM <= ?"
```

I'm happy to add tests, but don't see anything currently around the oracle dialect. If you'd like to see some, just point me to the right place and I'll have at it.

Thanks for reading!