### PR TITLE
Fix incompatibility issue with activerecord-turntable

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -22,6 +22,9 @@ module NewRelic
           end
 
           ::ActiveRecord::ConnectionAdapters::AbstractAdapter.module_eval do
+            if defined?(::ActiveRecord::Turntable)
+              include ::ActiveRecord::Turntable::ActiveRecordExt::AbstractAdapter
+            end
             include ::NewRelic::Agent::Instrumentation::ActiveRecord
           end
         end


### PR DESCRIPTION
I got incompatibility issue when using `activerecord-turntable`.
The problem is `activerecord-turntable` override log method of AbstractAdapter for logging current shard name. `activerecord-turntable` is loaded after `rpm`, and it override log method of `rpm`. Therefore, New Relic `rpm` can't collect mysql metric.
https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/active_record.rb#L32
https://github.com/drecom/activerecord-turntable/blob/master/lib/active_record/turntable/active_record_ext/abstract_adapter.rb#L10

I want to resolve the issue without breaking anything by load `activerecord-turntable` before `rpm` when using `activerecord-turntable`


