### PR TITLE
Remove Rails 5 deprecation warning by using Exception#cause.

### DIFF
--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -185,7 +185,7 @@ module NewRelic
 
       # extracts a stack trace from the exception for debugging purposes
       def extract_stack_trace(exception)
-        actual_exception = sense_method(exception, 'original_exception') || exception
+        actual_exception = sense_method(exception, 'cause') || sense_method(exception, 'original_exception') || exception
         sense_method(actual_exception, 'backtrace') || '<no stack trace>'
       end
 

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -30,6 +30,8 @@ class NewRelic::NoticedError
 
     if exception.nil?
       @message = '<no message>'
+    elsif exception.respond_to?('cause')
+      @message = (exception.cause || exception).to_s
     elsif exception.respond_to?('original_exception')
       @message = (exception.original_exception || exception).to_s
     else # exception is not nil, but does not respond to original_exception

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -173,6 +173,13 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     end
   end
 
+  def test_handles_exception_with_nil_cause
+    e = Exception.new('Buffy FOREVER')
+    e.stubs(:cause).returns(nil)
+    error = NewRelic::NoticedError.new(@path, e, @time)
+    assert_equal(error.message.to_s, 'Buffy FOREVER')
+  end
+
   def test_handles_exception_with_nil_original_exception
     e = Exception.new('Buffy FOREVER')
     e.stubs(:original_exception).returns(nil)


### PR DESCRIPTION
## Intro
I apologise if this work is already in progress, but figured I'd try and contribute. I'd heartily welcome some feedback on this PR, especially regarding naming and testing strategy.

## Issue
Currently, when using Rails 5.0.0 and ruby 2.3.1, deprecation warnings are received whenever the application generates a stack trace:
![screen shot 2016-07-08 at 10 58 37 am](https://cloud.githubusercontent.com/assets/13316387/16684088/f7bafdbe-44fa-11e6-993b-22cf370b39c0.png)
This can be replicated by running new relic in development and throwing an exception.

## Solution
To remove these warnings, the `error_collector.rb` and `noticed_error.rb` classes have been updated to make use of `Exception#cause` if it is available, by following existing patterns within the classes.

## Testing
Extra tests have been added to ensure order of precedence between the methods, which replace the original success test:
* `test_extract_stack_trace_uses_cause_first` - ErrorCollectorTest
* `test_extract_stack_trace_uses_original_exception_second` - ErrorCollectorTest
* `test_extract_stack_trace_uses_backtrace_last` - ErrorCollectorTest
* `test_handles_exception_with_nil_cause` - NoticedErrorTest

This initial fix has also been verified against the application that produced the above warnings.