### PR TITLE
DataMapper::Adapters::DataObjectsAdapter objects do not support #uri.

### DIFF
--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -147,7 +147,16 @@ module NewRelic
                 strategy = NewRelic::Agent::Database.record_sql_method(:slow_sql)
                 case strategy
                 when :obfuscated
-                  adapter_name = self.respond_to?(:options) ? self.options[:adapter] : self.repository.adapter.options[:adapter]
+                  adapter_name = if self.respond_to?(:options)
+                    self.options[:adapter]
+                  else
+                    if self.repository.adapter.respond_to?(:options)
+                      self.repository.adapter.options[:adapter]
+                    else
+                      # DataMapper < 0.10.0
+                      self.repository.adapter.uri.scheme
+                    end
+                  end
                   statement = NewRelic::Agent::Database::Statement.new(e.query, :adapter => adapter_name)
                   obfuscated_sql = NewRelic::Agent::Database.obfuscate_sql(statement)
                   e.instance_variable_set(:@query, obfuscated_sql)

--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -147,7 +147,7 @@ module NewRelic
                 strategy = NewRelic::Agent::Database.record_sql_method(:slow_sql)
                 case strategy
                 when :obfuscated
-                  adapter_name = self.respond_to?(:options) ? self.options[:adapter] : self.repository.adapter.uri.scheme
+                  adapter_name = self.respond_to?(:options) ? self.options[:adapter] : self.repository.adapter.options[:adapter]
                   statement = NewRelic::Agent::Database::Statement.new(e.query, :adapter => adapter_name)
                   obfuscated_sql = NewRelic::Agent::Database.obfuscate_sql(statement)
                   e.instance_variable_set(:@query, obfuscated_sql)


### PR DESCRIPTION
* Use `adapter.options[:adapter]` instead, which returns the adapter name as
  a String (ie: `"postgres"`).
* http://www.rubydoc.info/gems/dm-do-adapter/DataMapper/Adapters/DataObjectsAdapter
* http://www.rubydoc.info/gems/dm-core/DataMapper/Adapters/AbstractAdapter#options-instance_method