### PR TITLE
Fix versioning for cascading Grape routes

### DIFF
--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -11,43 +11,46 @@ module NewRelic
         extend self
 
         API_ENDPOINT   = 'api.endpoint'.freeze
+        API_VERSION    = 'api.version'.freeze
         FORMAT_REGEX   = /\(\/?\.[\:\w]*\)/.freeze # either :format (< 0.12.0) or .ext (>= 0.12.0)
         VERSION_REGEX  = /:version(\/|$)/.freeze
         EMPTY_STRING   = ''.freeze
         MIN_VERSION    = VersionNumber.new("0.2.0")
 
-        def handle_transaction(endpoint, class_name)
+        def handle_transaction(endpoint, class_name, version)
           return unless endpoint && route = endpoint.route
-          name_transaction(route, class_name)
+          name_transaction(route, class_name, version)
           capture_params(endpoint)
         end
 
-        def name_transaction(route, class_name)
-          txn_name = name_for_transaction(route, class_name)
+        def name_transaction(route, class_name, version)
+          txn_name = name_for_transaction(route, class_name, version)
           node_name = "Middleware/Grape/#{class_name}/call"
           Transaction.set_default_transaction_name(txn_name, :grape, node_name)
         end
 
         if defined?(Grape::VERSION) && VersionNumber.new(::Grape::VERSION) >= VersionNumber.new("0.16.0")
-          def name_for_transaction(route, class_name)
+          def name_for_transaction(route, class_name, version)
             action_name = route.path.sub(FORMAT_REGEX, EMPTY_STRING)
             method_name = route.request_method
+            version ||= route.version
 
-            if route.version
+            if version
               action_name = action_name.sub(VERSION_REGEX, EMPTY_STRING)
-              "#{class_name}-#{route.version}#{action_name} (#{method_name})"
+              "#{class_name}-#{version}#{action_name} (#{method_name})"
             else
               "#{class_name}#{action_name} (#{method_name})"
             end
           end
         else
-          def name_for_transaction(route, class_name)
+          def name_for_transaction(route, class_name, version)
             action_name = route.route_path.sub(FORMAT_REGEX, EMPTY_STRING)
             method_name = route.route_method
+            version ||= route.route_version
 
-            if route.route_version
+            if version
               action_name = action_name.sub(VERSION_REGEX, EMPTY_STRING)
-              "#{class_name}-#{route.route_version}#{action_name} (#{method_name})"
+              "#{class_name}-#{version}#{action_name} (#{method_name})"
             else
               "#{class_name}#{action_name} (#{method_name})"
             end
@@ -108,7 +111,8 @@ DependencyDetection.defer do
         ensure
           begin
             endpoint = env[::NewRelic::Agent::Instrumentation::GrapeInstrumentation::API_ENDPOINT]
-            ::NewRelic::Agent::Instrumentation::GrapeInstrumentation.handle_transaction(endpoint, self.class.name)
+            version = env[::NewRelic::Agent::Instrumentation::GrapeInstrumentation::API_VERSION]
+            ::NewRelic::Agent::Instrumentation::GrapeInstrumentation.handle_transaction(endpoint, self.class.name, version)
           rescue => e
             ::NewRelic::Agent.logger.warn("Error in Grape instrumentation", e)
           end

--- a/test/multiverse/suites/grape/grape_versioning_test.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test.rb
@@ -47,11 +47,23 @@ unless ::Grape::VERSION == '0.1.5'
     end
 
     #version from http accept header is not supported in older versions of grape
-    if NewRelic::VersionNumber.new(Grape::VERSION) >= NewRelic::VersionNumber.new('4.0.0')
+    if NewRelic::VersionNumber.new(Grape::VERSION) >= NewRelic::VersionNumber.new('0.16.0')
       def test_version_from_accept_version_header_is_recorded_in_transaction_name
         @app_class = GrapeVersioning::ApiV4
         get '/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4'
         assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV4-v4/fish (GET)')
+      end
+
+      def test_version_from_accept_version_header_is_recorded_in_transaction_name_cascading_versions_penultimate
+        @app_class = GrapeVersioning::CascadingAPI
+        get '/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4'
+        assert_metrics_recorded('Controller/Grape/GrapeVersioning::CascadingAPI-v4/fish (GET)')
+      end
+
+      def test_version_from_accept_version_header_is_recorded_in_transaction_name_cascading_versions_latest
+        @app_class = GrapeVersioning::CascadingAPI
+        get '/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v5'
+        assert_metrics_recorded('Controller/Grape/GrapeVersioning::CascadingAPI-v5/fish (GET)')
       end
     end
 

--- a/test/multiverse/suites/grape/grape_versioning_test_api.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test_api.rb
@@ -46,8 +46,8 @@ unless ::Grape::VERSION == '0.1.5'
 
     class ApiV4 < Grape::API
       #version from http accept header is not supported in older versions of grape
-      if NewRelic::VersionNumber.new(Grape::VERSION) >= NewRelic::VersionNumber.new('4.0.0')
-        version 'v4', :using => :accept_version_header
+      if NewRelic::VersionNumber.new(Grape::VERSION) >= NewRelic::VersionNumber.new('0.16.0')
+        version ['v4', 'v5'], :using => :accept_version_header
       end
 
       format :json
@@ -57,6 +57,23 @@ unless ::Grape::VERSION == '0.1.5'
           "api v4"
         end
       end
+    end
+
+    class CascadingAPI < Grape::API
+      #version from http accept header is not supported in older versions of grape
+      if NewRelic::VersionNumber.new(Grape::VERSION) >= NewRelic::VersionNumber.new('0.16.0')
+        version 'v5', :using => :accept_version_header
+      end
+
+      format :json
+
+      resource :fish do
+        get do
+          "api v5"
+        end
+      end
+
+      mount ApiV4
     end
 
     class Unversioned < Grape::API


### PR DESCRIPTION
We use Grape's ability to cascade versions, similar to [this post](http://code.dblock.org/2013/07/19/evolving-apis-using-grape-api-versioning.html). When doing so, the NR grape instrumentation has two issues:

1. If there is only a version of an endpoint in the earliest versions, the transaction name will include all the versions it applies to, ex: `["1.0", "2.0", "3.0"]: /my/endpoint (GET)`
2. If there is a newer version, based on some nuance of Grape cascades, the transaction name will always be the most recent.

The changes in this PR start using the `api.version` key that Grape puts into the rack env once it decides which route/version is actually going to respond to the call. I've tested locally and this fixes the issues in our grape app.

Note: I believe the tests for the `Accept-Version` header were guarded by an overly ambitious version guard and were not running (they were looking for v 4.0.0 of grape, but the latest is 0.16). I've updated so these run if the grape version >= 0.16.0.