### PR TITLE
Add instrumentation for the http.rb gem

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1297,6 +1297,14 @@ module NewRelic
           :allowed_from_server => false,
           :description  => 'If <code>true</code>, the agent won\'t install instrumentation for the typhoeus gem.'
         },
+        :disable_httprb => {
+          :default      => false,
+          :public       => true,
+          :type         => Boolean,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description  => 'If <code>true</code>, the agent won\'t install instrumentation for the http.rb gem.'
+        },
         :disable_middleware_instrumentation => {
           :default      => false,
           :public       => true,

--- a/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+
+module NewRelic
+  module Agent
+    module HTTPClients
+      class HTTPResponse
+        attr_reader :response
+
+        def initialize(response)
+          @response = response
+        end
+
+        def [](key)
+          response.headers.each do |k,v|
+            if key.downcase == k.downcase
+              return v
+            end
+          end
+          nil
+        end
+
+        def to_hash
+          response.headers
+        end
+      end
+
+      class HTTPRequest
+        attr_reader :request, :uri
+
+        def initialize(request)
+          @request = request
+          @uri = request.uri
+        end
+
+        def type
+          "http.rb"
+        end
+
+        def method
+          request.verb
+        end
+
+        def host
+          request.socket_host
+        end
+
+        def [](key)
+          request.headers[key]
+        end
+
+        def []=(key, value)
+          request.headers[key] = value
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
@@ -13,12 +13,8 @@ module NewRelic
         end
 
         def [](key)
-          response.headers.each do |k,v|
-            if key.downcase == k.downcase
-              return v
-            end
-          end
-          nil
+          _, value = response.headers.find { |k,_| key.downcase == k.downcase }
+          value unless value.nil?
         end
 
         def to_hash
@@ -38,12 +34,16 @@ module NewRelic
           "http.rb"
         end
 
-        def method
-          request.verb
+        def host
+          if hostname = self['host']
+            hostname.split(':').first
+          else
+            request.host
+          end
         end
 
-        def host
-          request.socket_host
+        def method
+          request.verb.upcase
         end
 
         def [](key)

--- a/lib/new_relic/agent/instrumentation/http.rb
+++ b/lib/new_relic/agent/instrumentation/http.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+
+DependencyDetection.defer do
+  named :http_rb
+
+  depends_on do
+    defined?(HTTP) && defined?(HTTP::Client)
+  end
+
+  executes do
+    ::NewRelic::Agent.logger.info 'Installing http.rb instrumentation'
+    require 'new_relic/agent/cross_app_tracing'
+    require 'new_relic/agent/http_clients/http_rb_wrappers'
+  end
+
+  executes do
+    class HTTP::Client
+      def perform_with_newrelic_trace(request, options)
+        wrapped_request = NewRelic::Agent::HTTPClients::HTTPRequest.new(request)
+
+        NewRelic::Agent::CrossAppTracing.tl_trace_http_request( wrapped_request ) do
+          # RUBY-1244 Disable further tracing in request to avoid double
+          # counting if connection wasn't started (which calls request again).
+          NewRelic::Agent.disable_all_tracing do
+            perform_without_newrelic_trace( request, options )
+          end
+        end
+      end
+
+      alias perform_without_newrelic_trace perform
+      alias perform perform_with_newrelic_trace
+    end
+  end
+end

--- a/lib/new_relic/agent/supported_versions.rb
+++ b/lib/new_relic/agent/supported_versions.rb
@@ -230,6 +230,13 @@ module NewRelic
           "Supported for all agent-supported versions of Ruby.",
           "For more information on supported HTTP clients see http://docs.newrelic.com/docs/ruby/ruby-http-clients."]
       },
+      :httprb =>
+      {
+        :type        => :http,
+        :supported   => [ ">= 0.9.9"],
+        :url         => "https://rubygems.org/gems/http",
+        :feed        => "https://rubygems.org/gems/http/versions.atom"
+      },
 
       # Other
       :sunspot =>

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -87,7 +87,7 @@ module Multiverse
       "api"           => ["grape"],
       "background"    => ["delayed_job", "rake", "resque", "sidekiq"],
       "database"      => ["datamapper", "mongo", "redis", "sequel"],
-      "httpclients"   => ["curb", "excon", "httpclient", "typhoeus", "net_http"],
+      "httpclients"   => ["curb", "excon", "httpclient", "typhoeus", "net_http", "httprb"],
       "rails"         => ["active_record", "rails"],
       "serialization" => ["json", "marshalling", "yajl"],
       "sinatra"       => ["sinatra", "padrino"],

--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -1,0 +1,19 @@
+suite_condition("http.rb is only supported for versions >= 2.0.0") do
+  RUBY_VERSION >= '2.0.0'
+end
+
+httprb_versions = %w(2.0.3
+                     2.0.2
+                     2.0.1
+                     2.0.0
+                     1.0.4
+                     0.9.9
+                     0.8.14
+                     0.7.4)
+
+httprb_versions.each do |httprb_version|
+  gemfile <<-RB
+    gem 'http', '~> #{httprb_version}'
+    gem 'rack'
+  RB
+end

--- a/test/multiverse/suites/httprb/config/newrelic.yml
+++ b/test/multiverse/suites/httprb/config/newrelic.yml
@@ -1,0 +1,18 @@
+---
+development:
+  error_collector:
+    enabled: true
+  apdex_t: 0.5
+  ssl: false
+  monitor_mode: true
+  license_key: bootstrap_newrelic_admin_license_key_000
+  developer_mode: false
+  app_name: test
+  host: 127.0.0.1
+  api_host: 127.0.0.1
+  transaction_tracer:
+    record_sql: obfuscated
+    enabled: true
+    stack_trace_threshold: 0.5
+    transaction_threshold: 1.0
+  capture_params: false

--- a/test/multiverse/suites/httprb/httprb_test.rb
+++ b/test/multiverse/suites/httprb/httprb_test.rb
@@ -1,0 +1,78 @@
+# encoding: utf-8
+# This file is distributed under New Relic"s license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+
+require "http"
+require "newrelic_rpm"
+require "http_client_test_cases"
+
+class HTTPTest < Minitest::Test
+  include HttpClientTestCases
+
+  def client_name
+    "http.rb"
+  end
+
+  def is_unsupported_1x?
+    defined?(::HTTP::VERSION) && HTTP::VERSION < '1.0.0'
+  end
+
+  def get_response(url=nil, headers=nil)
+    HTTP.get(url || default_url, :headers => headers)
+  end
+
+  def head_response
+    HTTP.head(default_url)
+  end
+
+  def post_response
+    HTTP.post(default_url, :body => "")
+  end
+
+  def put_response
+    HTTP.put(default_url, :body => "")
+  end
+
+  def delete_response
+    HTTP.delete(default_url, :body => "")
+  end
+
+  def body(res)
+    res.body.to_s
+  end
+
+  def request_instance
+    options = {
+      verb: :get,
+      uri: 'http://newrelic.com'
+    }
+
+    httprb_req =
+      if is_unsupported_1x?
+        HTTP::Request.new(*options.values)
+      else
+        HTTP::Request.new(options)
+      end
+
+    ::NewRelic::Agent::HTTPClients::HTTPRequest.new(httprb_req)
+  end
+
+  def response_instance(headers = {})
+    options = {
+      status: 200,
+      version: '1.1',
+      headers: headers,
+      body: ''
+    }
+
+    httprb_resp =
+      if is_unsupported_1x?
+        HTTP::Response.new(*options.values)
+      else
+        HTTP::Response.new(options)
+      end
+
+    ::NewRelic::Agent::HTTPClients::HTTPResponse.new(httprb_resp)
+  end
+
+end


### PR DESCRIPTION
Based on [Talkdesk/newrelic_httprb](https://github.com/Talkdesk/newrelic_httprb), but also including running specs to test it under NewRelic's `HttpClientTestCases` harness.

Functional testing using `bundle exec rake test:multiverse[httprb]`.

Tested against all minor versions since `0.7.4` and all patch levels of the latest `2.0` branch.