### PR TITLE
Do not install_newrelic_job_tracer into Delayed::Job if it has been done already

### DIFF
--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -98,9 +98,11 @@ DependencyDetection.defer do
         NewRelic::DelayedJobInjection.worker_name = worker_name
 
         if defined?(::Delayed::Job) && ::Delayed::Job.method_defined?(:invoke_job)
-          ::NewRelic::Agent.logger.info 'Installing DelayedJob instrumentation [part 2/2]'
-          install_newrelic_job_tracer
-          NewRelic::Control.instance.init_plugin :dispatcher => :delayed_job
+          if !(::Delayed::Job.method_defined?(:invoke_job_without_new_relic) )
+            ::NewRelic::Agent.logger.info 'Installing DelayedJob instrumentation [part 2/2]'
+            install_newrelic_job_tracer
+            NewRelic::Control.instance.init_plugin :dispatcher => :delayed_job
+          end
         else
           NewRelic::Agent.logger.warn("Did not find a Delayed::Job class responding to invoke_job, aborting DJ instrumentation")
         end


### PR DESCRIPTION
When using multiple Delayed::Worker instances in the same process, the Delayed::Job class gets patched each time the worker is created.
Small patch to ensure it is only done once.