### PR TITLE
route rpm to container-based infrastructure `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 language: ruby
 
-sudo: required
+sudo: false
 
 script: ./test/script/ci.sh
 


### PR DESCRIPTION
Hi @kwugirl 

Let's try this out, I think with the custom config + `sudo: false` it should work properly. 
