### PR TITLE
'ignore_url_regexes' should prevent all instrumentation

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -53,9 +53,19 @@ module NewRelic::Rack
       NewRelic::Agent.config[:'browser_monitoring.auto_instrument'] &&
         status == 200 &&
         !env[ALREADY_INSTRUMENTED_KEY] &&
+        !is_route_ignored?(env) &&
         is_html?(headers) &&
         !is_attachment?(headers) &&
         !is_streaming?(env)
+    end
+
+    def is_route_ignored?(env)
+      return unless env['PATH_INFO']
+      return if (rules = NewRelic::Agent.config[:"rules.ignore_url_regexes"]).empty?
+
+      rules.any? do |rule|
+        env['PATH_INFO'].match(rule)
+      end
     end
 
     def is_html?(headers)

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -66,7 +66,8 @@ EOL
       :'rum.enabled' => true,
       :license_key => 'a' * 40,
       :js_agent_loader => 'loader',
-      :disable_harvest_thread => true
+      :disable_harvest_thread => true,
+      :'rules.ignore_url_regexes' => [/^\/skip_instrument/]
     }
     NewRelic::Agent.config.add_config_for_testing(@config)
   end
@@ -82,6 +83,11 @@ EOL
     in_transaction do
       assert NewRelic::Agent.browser_timing_header.size > 0
     end
+  end
+
+  def test_should_not_instrument_blacklisted_paths
+    assert !app.should_instrument?({'PATH_INFO' => '/skip_instrument'}, 200, {'Content-Type' => 'text/html'}), "Expected not to instrument requests for blacklisted path."
+    assert app.should_instrument?({'PATH_INFO' => '/should_instrument'}, 200, {'Content-Type' => 'text/html'}), "Expected to instrument requests for not blacklisted path."
   end
 
   def test_should_only_instrument_successful_html_requests


### PR DESCRIPTION
Giving the name of the config: `rules.ignore_url_regexes` I was expecting and under the impression that it would prevent ALL kind of data from being collected from the specified url's.
Imagine my surprise when I realized that my `Browser` data was wrong because this configuration would only suppress the reporting of APM data...

Trying to search for a better documentation or a simple way to prevent ALL data from being reported to New Relic I found out that there was no option for doing that.

What do you guys think of making the `ignore_url_regexes` to really ignore every kind of instrumentation by not adding the browser monitoring as well?
