### PR TITLE
DataObjects::ConnectionError inherits from SQLError but sets #uri to nil

### DIFF
--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -137,6 +137,8 @@ module NewRelic
 
             begin
               self.send("#{method_name}_without_newrelic", *args, &blk)
+            rescue ::DataObjects::ConnectionError => e
+              raise
             rescue ::DataObjects::SQLError => e
               e.uri.gsub!(PASSWORD_REGEX, AMPERSAND) if e.uri.include?(PASSWORD_PARAM)
 


### PR DESCRIPTION
When DataObjects cannot connect to the database (ex: could not resolve host) it will raise a [DataObjects::ConnectionError](http://www.rubydoc.info/gems/data_objects/DataObjects/ConnectionError), which inherits from [DataObjects::SQLError](http://www.rubydoc.info/gems/data_objects/DataObjects/ConnectionError). The only difference is that the `#uri` attribute is `nil`, since no connection has been made yet. To avoid testing `e.uri.include?(PASSWORD_PARAM)`, this change guards against this by catching and re-raising `DataObjects::ConnectionError` exceptions.