### PR TITLE
Capistrano deploy_notice doesn't extract changelog w/out revisions

### DIFF
--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -63,9 +63,11 @@ namespace :newrelic do
   end
 
   def lookup_changelog
-    debug "Retrieving changelog for New Relic Deployment details"
     previous_revision = fetch(:previous_revision)
     current_revision = fetch(:current_revision)
+    return unless current_revision && previous_revision
+
+    debug "Retrieving changelog for New Relic Deployment details"
 
     if scm == :git
       log_command = "git --no-pager log --no-color --pretty=format:'  * %an: %s' " +


### PR DESCRIPTION
Ensure we have a value for the current/previous revisions before attempting to pull the changelog for revisions "previous..current".  Fixes error `fatal: ..: '..' is outside repository` produced by string with nil values for both.

Previously, if you ran this task outside of a `deploy` sequence, it throws an error when trying to extract the git changlog:

```
fatal: ..: '..' is outside repository
Recorded deployment to 'yourapp (Staging)' (2016-12-06 15:20:41 -0500)
00:00 newrelic:notice_deployment
      Uploaded deployment information to New Relic
```