### PR TITLE
deployment notification - run only on primary :newrelic_role

### DIFF
--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -10,7 +10,7 @@ namespace :newrelic do
   desc "Record a deployment in New Relic (newrelic.com)"
   task :notice_deployment do
     if fetch(:newrelic_role)
-      on roles(fetch(:newrelic_role)) do
+      on primary fetch(:newrelic_role) do
         send_deployment_notification_to_newrelic
       end
     else


### PR DESCRIPTION
when assigned role to :newrelic_role variable, only run deployment notice on primary