### PR TITLE
Support NEW_RELIC_ENV when Rails is detected

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -12,7 +12,7 @@ module NewRelic
       class Rails < NewRelic::Control::Frameworks::Ruby
 
         def env
-          @env ||= RAILS_ENV.dup
+          @env ||= ( ENV['NEW_RELIC_ENV'] || RAILS_ENV.dup )
         end
 
         # Rails can return an empty string from this method, causing

--- a/lib/new_relic/control/frameworks/rails3.rb
+++ b/lib/new_relic/control/frameworks/rails3.rb
@@ -16,7 +16,7 @@ module NewRelic
       class Rails3 < NewRelic::Control::Frameworks::Rails
 
         def env
-          @env ||= ::Rails.env.to_s
+          @env ||= ( ENV['NEW_RELIC_ENV'] || ::Rails.env.to_s )
         end
 
         def rails_root


### PR DESCRIPTION
I have a use case where I need to boot the agent in a Rails app suing a different new_relic env. While the app boot in production I need to configure the agent under the qa environment. Using the NEW_RELIC_ENV is the most easy way to do this but looks like when rails is detected teh env var is not considered.

Is this a mergeable approach? 