### PR TITLE
Fixed issue with NEW_RELIC_ENV environment variable not being used for Rails apps

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -11,10 +11,6 @@ module NewRelic
       # etc.
       class Rails < NewRelic::Control::Frameworks::Ruby
 
-        def env
-          @env ||= RAILS_ENV.dup
-        end
-
         # Rails can return an empty string from this method, causing
         # the agent not to start even when it is properly in a rails 3
         # application, so we test the value to make sure it actually

--- a/lib/new_relic/control/frameworks/rails3.rb
+++ b/lib/new_relic/control/frameworks/rails3.rb
@@ -15,10 +15,6 @@ module NewRelic
       # not differ
       class Rails3 < NewRelic::Control::Frameworks::Rails
 
-        def env
-          @env ||= ::Rails.env.to_s
-        end
-
         def rails_root
           ::Rails.root.to_s
         end

--- a/test/config/test_control.rb
+++ b/test/config/test_control.rb
@@ -5,9 +5,12 @@
 require 'new_relic/control/frameworks/rails'
 require 'new_relic/control/frameworks/rails3'
 require 'new_relic/control/frameworks/rails4'
+require 'new_relic/control/frameworks/rails5'
 
 if defined?(::Rails)
   parent_class = case ::Rails::VERSION::MAJOR.to_i
+  when 5
+    NewRelic::Control::Frameworks::Rails5
   when 4
     NewRelic::Control::Frameworks::Rails4
   when 3
@@ -23,7 +26,9 @@ class NewRelic::Control::Frameworks::Test < parent_class
 
   def app
     if defined?(::Rails) && defined?(::Rails::VERSION)
-      if ::Rails::VERSION::MAJOR.to_i == 4
+      if ::Rails::VERSION::MAJOR.to_i == 5
+        :rails5
+      elsif ::Rails::VERSION::MAJOR.to_i == 4
         :rails4
       elsif ::Rails::VERSION::MAJOR.to_i == 3
         :rails3

--- a/test/new_relic/control/frameworks/rails_test.rb
+++ b/test/new_relic/control/frameworks/rails_test.rb
@@ -26,4 +26,16 @@ class NewRelic::Control::Frameworks::RailsTest < Minitest::Test
       NewRelic::Control.instance.install_browser_monitoring(config)
     end
   end
+
+  def test_new_relic_env_should_be_used_when_specified_in_rails
+    with_constant_defined(:RAILS_ENV, "test") do
+      with_environment("NEW_RELIC_ENV" => "my_env") do
+        local_env = mock('local env')
+        assert_equal "my_env", NewRelic::Control::Frameworks::Rails.new(local_env).env
+        assert_equal "my_env", NewRelic::Control::Frameworks::Rails3.new(local_env).env
+        assert_equal "my_env", NewRelic::Control::Frameworks::Rails4.new(local_env).env
+        assert_equal "my_env", NewRelic::Control::Frameworks::Rails5.new(local_env).env
+      end
+    end
+  end
 end


### PR DESCRIPTION
(Includes test)

See comment in related pull request, and why this pull request would be my preferred way of fixing:

https://github.com/newrelic/rpm/pull/264#issuecomment-285362792