### PR TITLE
Fix git scm detection on capistrano3 recipe

### DIFF
--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -34,7 +34,7 @@ namespace :newrelic do
       user        = fetch(:newrelic_user)
       license_key = fetch(:newrelic_license_key)
 
-      unless scm == :none
+      if (respond_to?(:scm_plugin_installed?) && scm_plugin_installed?) || (scm.present? && scm != :none)
         changelog ||= lookup_changelog
         rev       ||= fetch(:current_revision)
       end
@@ -69,7 +69,7 @@ namespace :newrelic do
 
     debug "Retrieving changelog for New Relic Deployment details"
 
-    if scm == :git
+    if Rake::Task.task_defined?("git:check")
       log_command = "git --no-pager log --no-color --pretty=format:'  * %an: %s' " +
                     "--abbrev-commit --no-merges #{previous_revision}..#{current_revision}"
       `#{log_command}`


### PR DESCRIPTION
Prior to capistrano v3.7.0, scm can be fetched through Capistrano::DSL

Since capistrano v3.7.0, scm has been deprecated and replaced by plugin system, in which
scm will simply return nil.

An alternative solution would be to check if scm specific rake task is present, eg: "git:check", "hg:check", etc