### PR TITLE
monitoring should default to off in test environment

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -272,7 +272,9 @@ module NewRelic
           :description => 'Specify the <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/installation-configuration/name-your-application">application name</a> used to aggregate data in the New Relic UI. To report data to <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app">multiple apps at the same time</a>, specify a list of names separated by a semicolon <code>;</code>. For example, <code>MyApp</code> or <code>MyStagingApp;Instance1</code>.'
         },
         :monitor_mode => {
-          :default => value_of(:enabled),
+          :default => Proc.new {
+            NewRelic::Agent.config[:enabled] ? NewRelic::Control.instance.env != 'test' : false
+          },
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -19,7 +19,7 @@ module NewRelic
         @agent.agent_command_router.stubs(:new_relic_service).returns(@agent.service)
         @agent.stubs(:start_worker_thread)
 
-        @config = { :license_key => "a" * 40 }
+        @config = { :license_key => "a" * 40, :monitor_mode => true }
         NewRelic::Agent.config.add_config_for_testing(@config)
       end
 


### PR DESCRIPTION
monitor_mode should default to false when newrelic's test_mode is true. this is consistent with the default values generated for newrelic.yml: https://github.com/newrelic/rpm/blob/4.1.0.333/newrelic.yml#L33-L36 

test_mode should default to true when env == 'test'.
