### PR TITLE
Stop packaging test files with the gem

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -31,7 +31,7 @@ EOS
     "newrelic.yml"
   ]
 
-  file_list = `git ls-files`.split
+  file_list = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   build_file_path = 'lib/new_relic/build.rb'
   file_list << build_file_path if File.exist?(build_file_path)
   s.files = file_list


### PR DESCRIPTION
It reduces the size of the gem by half, from 645K to 294K. The default for new gems (created by bundler) is not to include test files. See bundler/bundler#3207