### PR TITLE
Check Rails::VERSION instead of just Rails

### DIFF
--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -165,7 +165,7 @@ class NewRelic::NoticedError
       @exception_class_name = UNKNOWN_ERROR_CLASS_NAME
       @message = NIL_ERROR_MESSAGE
     else
-      if defined?(Rails) && Rails::VERSION::MAJOR < 5 && exception.respond_to?(:original_exception)
+      if defined?(Rails::VERSION) && Rails::VERSION::MAJOR < 5 && exception.respond_to?(:original_exception)
         exception = exception.original_exception || exception
       end
       @exception_class_name = exception.is_a?(Exception) ? exception.class.name : UNKNOWN_ERROR_CLASS_NAME


### PR DESCRIPTION
Sometimes gems will introduce the module 'Rails' just to get around internal works (sucks but its true);

Since this is trying to access something that could or could not be defined; why not just check the entire tree instead for safety reasons.

Anyone that actually has Rails should have the VERSION field.

FIXES: this stops error collecting if Rails module is defined; but Rails::VERSION is not.