### PR TITLE
Verify uri.host before downcasing to prevent NilClass error

### DIFF
--- a/lib/new_relic/agent/http_clients/uri_util.rb
+++ b/lib/new_relic/agent/http_clients/uri_util.rb
@@ -37,7 +37,7 @@ module NewRelic
               uri = ::URI.parse(url)
             end
           end
-          uri.host.downcase!
+          uri.host.downcase! unless uri.host.nil?
           uri
         end
 

--- a/test/new_relic/agent/http_clients/uri_util_test.rb
+++ b/test/new_relic/agent/http_clients/uri_util_test.rb
@@ -33,12 +33,12 @@ class URIUtilTest < Minitest::Test
   end
 
   def test_filtered_uri_reflects_use_of_ssl
-    assert_filtered('https://foo.com/bar/baz',
+    assert_filtered("https://foo.com/bar/baz",
                     "https://foo.com/bar/baz")
   end
 
   def test_filtered_uri_reflects_use_of_ssl_with_custom_port
-    assert_filtered('https://foo.com:9999/bar/baz',
+    assert_filtered("https://foo.com:9999/bar/baz",
                     "https://foo.com:9999/bar/baz")
   end
 
@@ -57,8 +57,17 @@ class URIUtilTest < Minitest::Test
                     "http://foo.com/bar/baz")
   end
 
+  def test_invalid_url_normalization
+    assert_normalized("foobarbaz",
+                      "foobarbaz")
+  end
+
   def assert_filtered(original, expected)
     assert_equal(expected, NewRelic::Agent::HTTPClients::URIUtil.filter_uri(URI(original)))
+  end
+
+  def assert_normalized(original, expected)
+    assert_equal(expected, NewRelic::Agent::HTTPClients::URIUtil.parse_and_normalize_url(URI(original)).to_s)
   end
 
 end


### PR DESCRIPTION
# Overview
Normalization of external hostnames was introduced in `v4.1.0`. One of the steps of this normalization is downcasing external hostnames.

## Problem
In case of an invalid URL (user entered information or specs), the hostname can be `nil`. Then calling `downcase!` in such object would result in `NoMethodError: undefined method 'downcase' for nil:NilClass`.

## Proposed Solution
A simple `nil` check before trying to downcase the hostname would solve this, since if no hostname is available, there's no need for using `downcase!`