### PR TITLE
Requires Datastores in Agent.

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -47,6 +47,7 @@ module NewRelic
     require 'new_relic/agent/busy_calculator'
     require 'new_relic/agent/sampler'
     require 'new_relic/agent/database'
+    require 'new_relic/agent/datastores'
     require 'new_relic/agent/pipe_channel_manager'
     require 'new_relic/agent/configuration'
     require 'new_relic/agent/rules_engine'


### PR DESCRIPTION
Previously this module was being defined implictly by
other classes in its namespace, without the methods being defined.