### PR TITLE
Support Postgis ActiveRecord adapter as Postgres

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -156,6 +156,9 @@ module NewRelic
 
           # https://rubygems.org/gems/activerecord-jdbcpostgresql-adapter
           "jdbcpostgresql" => "Postgres",
+          
+          # https://rubygems.org/gems/activerecord-postgis-adapter
+          "postgis"    => "Postgres",
 
           # https://rubygems.org/gems/activerecord-jdbcsqlite3-adapter
           "jdbcsqlite3"    => "SQLite",
@@ -197,7 +200,8 @@ module NewRelic
             "jdbcmysql"  => :mysql,
 
             "postgresql"     => :postgres,
-            "jdbcpostgresql" => :postgres
+            "jdbcpostgresql" => :postgres,
+            "postgis"        => :postgres
           }.freeze
 
           DATASTORE_DEFAULT_PORTS = {


### PR DESCRIPTION
The postgis adapter is wraps the original postgres adapter https://github.com/rgeo/activerecord-postgis-adapter/blob/master/lib/active_record/connection_adapters/postgis_adapter.rb#L30

Right now APM falls back to ActiveRecord instead of Postgres