### PR TITLE
Support slow SQL traces with postgis adapter

### DIFF
--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -231,13 +231,14 @@ module NewRelic
 
         private
 
+        POSTGIS_PREFIX  = 'postgis'.freeze
         POSTGRES_PREFIX = 'postgres'.freeze
         MYSQL_PREFIX    = 'mysql'.freeze
         MYSQL2_PREFIX   = 'mysql2'.freeze
         SQLITE_PREFIX   = 'sqlite'.freeze
 
         def symbolized_adapter(adapter)
-          if adapter.start_with? POSTGRES_PREFIX
+          if adapter.start_with?(POSTGRES_PREFIX) || adapter == POSTGIS_PREFIX
             :postgres
           elsif adapter == MYSQL_PREFIX
             :mysql

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -40,6 +40,12 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     assert_equal(:sqlite, statement.adapter)
   end
 
+  def test_adapter_from_config_string_postgis
+    config = { :adapter => 'postgis' }
+    statement = NewRelic::Agent::Database::Statement.new('some query', config)
+    assert_equal(:postgres, statement.adapter)
+  end
+
   # An ActiveRecord::Result is what you get back when executing a
   # query using exec_query on the connection, which is what we're
   # doing now for explain plans in AR4 instrumentation


### PR DESCRIPTION
Explicit PostGIS support was recently added, but slow SQL traces still weren't working because postgis didn't translate to a supported adapter in this part of the code. This fixes that.