### PR TITLE
Monitor mode default false in development/test

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -272,7 +272,9 @@ module NewRelic
           :description => 'Specify the <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/installation-configuration/name-your-application">application name</a> used to aggregate data in the New Relic UI. To report data to <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app">multiple apps at the same time</a>, specify a list of names separated by a semicolon <code>;</code>. For example, <code>MyApp</code> or <code>MyStagingApp;Instance1</code>.'
         },
         :monitor_mode => {
-          :default => value_of(:enabled),
+          :default => Proc.new {
+            NewRelic::Agent.config[:enabled] ? NewRelic::Control.instance.env != 'test' : false
+          },
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -273,7 +273,8 @@ module NewRelic
         },
         :monitor_mode => {
           :default => Proc.new {
-            NewRelic::Agent.config[:enabled] ? NewRelic::Control.instance.env != 'test' : false
+            development_or_test =  %w(test development).include?(NewRelic::Control.instance.env)
+            NewRelic::Agent.config[:enabled] ? !development_or_test : false
           },
           :public => true,
           :type => Boolean,

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -408,7 +408,8 @@ def find_all_nodes_with_name_matching(transaction_sample, regexes)
 end
 
 def with_config(config_hash, at_start=true)
-  config = NewRelic::Agent::Configuration::DottedHash.new(config_hash, true)
+  defaults = { :monitor_mode => true }
+  config = NewRelic::Agent::Configuration::DottedHash.new(defaults.merge(config_hash), true)
   NewRelic::Agent.config.add_config_for_testing(config, at_start)
   NewRelic::Agent.instance.refresh_attribute_filter
   begin

--- a/test/multiverse/suites/rails/config/newrelic.yml
+++ b/test/multiverse/suites/rails/config/newrelic.yml
@@ -4,6 +4,7 @@ common: &default_settings
   port: <%= $collector && $collector.port %>
   app_name: Rails multiverse test app
   enabled: true
+  monitor_mode: true
   ssl: false
   apdex_t: 1.0
   capture_params: true

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -19,7 +19,7 @@ module NewRelic
         @agent.agent_command_router.stubs(:new_relic_service).returns(@agent.service)
         @agent.stubs(:start_worker_thread)
 
-        @config = { :license_key => "a" * 40 }
+        @config = { :license_key => "a" * 40, :monitor_mode => true }
         NewRelic::Agent.config.add_config_for_testing(@config)
       end
 


### PR DESCRIPTION
This piggy-backs off of the work in this PR: https://github.com/newrelic/rpm/pull/267

This attempts to set a sensible default for `monitor_mode`, i.e. it should be disabled in development/test. There are cases where it is cumbersome to control Newrelic integration with yml/env configuration. In my specific case, we use a boilerplate gem in all of our apps that includes this one, so ideally we would be able to avoid NR configuration in each new app.