### PR TITLE
Make constant defined checks more explicit for Rails::VERSION

### DIFF
--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -183,7 +183,7 @@ module NewRelic
 
       # extracts a stack trace from the exception for debugging purposes
       def extract_stack_trace(exception)
-        actual_exception = if defined?(Rails) && Rails::VERSION::MAJOR < 5
+        actual_exception = if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR < 5
                              sense_method(exception, :original_exception) || exception
                            else
                              exception

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -94,7 +94,7 @@ DependencyDetection.defer do
   executes do
     require 'new_relic/agent/instrumentation/active_record_helper'
 
-    if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 3
+    if defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i == 3
       ActiveSupport.on_load(:active_record) do
         ::NewRelic::Agent::Instrumentation::ActiveRecord.insert_instrumentation
       end

--- a/lib/new_relic/agent/instrumentation/rails/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails/action_controller.rb
@@ -86,7 +86,7 @@ DependencyDetection.defer do
   end
 
   depends_on do
-    defined?(Rails) && Rails::VERSION::MAJOR.to_i == 2
+    defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR.to_i == 2
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -66,7 +66,7 @@ DependencyDetection.defer do
   @name = :rails3_controller
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 3
+    defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i == 3
   end
 
   depends_on do
@@ -88,7 +88,7 @@ DependencyDetection.defer do
   @name = :rails30_view
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 3 && ::Rails::VERSION::MINOR.to_i == 0
+    defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i == 3 && ::Rails::VERSION::MINOR.to_i == 0
   end
 
   depends_on do
@@ -127,7 +127,7 @@ DependencyDetection.defer do
   # We can't be sure that this will work with future versions of Rails 3.
   # Currently enabled for Rails 3.1 and 3.2
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 3 && ([1,2].member?(::Rails::VERSION::MINOR.to_i))
+    defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i == 3 && ([1,2].member?(::Rails::VERSION::MINOR.to_i))
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails4/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails4/action_controller.rb
@@ -9,7 +9,7 @@ DependencyDetection.defer do
   @name = :rails4_controller
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 4
+    defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i == 4
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails4/action_view.rb
+++ b/lib/new_relic/agent/instrumentation/rails4/action_view.rb
@@ -8,7 +8,7 @@ DependencyDetection.defer do
   @name = :rails4_view
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 4
+    defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i == 4
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails5/action_cable.rb
+++ b/lib/new_relic/agent/instrumentation/rails5/action_cable.rb
@@ -8,7 +8,7 @@ DependencyDetection.defer do
   @name = :rails5_action_cable
 
   depends_on do
-    defined?(::Rails) &&
+    defined?(::Rails::VERSION::MAJOR) &&
      ::Rails::VERSION::MAJOR.to_i == 5 &&
        defined?(::ActionCable)
   end

--- a/lib/new_relic/agent/instrumentation/rails5/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails5/action_controller.rb
@@ -9,7 +9,7 @@ DependencyDetection.defer do
   @name = :rails5_controller
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 5
+    defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i == 5
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails5/action_view.rb
+++ b/lib/new_relic/agent/instrumentation/rails5/action_view.rb
@@ -8,7 +8,7 @@ DependencyDetection.defer do
   @name = :rails5_view
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 5
+    defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i == 5
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails_middleware.rb
+++ b/lib/new_relic/agent/instrumentation/rails_middleware.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
   end
 
   depends_on do
-    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3
+    defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i >= 3
   end
 
   executes do

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -165,7 +165,7 @@ class NewRelic::NoticedError
       @exception_class_name = UNKNOWN_ERROR_CLASS_NAME
       @message = NIL_ERROR_MESSAGE
     else
-      if defined?(Rails) && Rails::VERSION::MAJOR < 5 && exception.respond_to?(:original_exception)
+      if defined?(Rails::VERSION) && Rails::VERSION::MAJOR < 5 && exception.respond_to?(:original_exception)
         exception = exception.original_exception || exception
       end
       @exception_class_name = exception.is_a?(Exception) ? exception.class.name : UNKNOWN_ERROR_CLASS_NAME

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -165,7 +165,7 @@ class NewRelic::NoticedError
       @exception_class_name = UNKNOWN_ERROR_CLASS_NAME
       @message = NIL_ERROR_MESSAGE
     else
-      if defined?(Rails::VERSION) && Rails::VERSION::MAJOR < 5 && exception.respond_to?(:original_exception)
+      if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR < 5 && exception.respond_to?(:original_exception)
         exception = exception.original_exception || exception
       end
       @exception_class_name = exception.is_a?(Exception) ? exception.class.name : UNKNOWN_ERROR_CLASS_NAME

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -248,7 +248,7 @@ class NewRelic::Agent::ErrorCollectorTest < Minitest::Test
     assert_equal('<no stack trace>', @error_collector.extract_stack_trace(Exception.new))
   end
 
-  if defined?(Rails) && Rails::VERSION::MAJOR < 5
+  if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR < 5
     def test_extract_stack_trace_from_original_exception
       orig = mock('original', :backtrace => "STACK STACK STACK")
       exception = mock('exception', :original_exception => orig)

--- a/test/new_relic/agent/instrumentation/action_cable_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_cable_subscriber_test.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
-if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 5
+if defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i >= 5
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','test_helper'))
 require 'new_relic/agent/instrumentation/action_cable_subscriber'

--- a/test/new_relic/agent/instrumentation/active_record_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_subscriber_test.rb
@@ -4,7 +4,7 @@
 
 MIN_RAILS_VERSION = 4
 
-if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= MIN_RAILS_VERSION && !NewRelic::LanguageSupport.jruby?
+if defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR.to_i >= MIN_RAILS_VERSION && !NewRelic::LanguageSupport.jruby?
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','test_helper'))
 require 'new_relic/agent/instrumentation/active_record_subscriber'

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -182,7 +182,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     assert_equal(error.message.to_s, 'Buffy FOREVER')
   end
 
-  if defined?(Rails) && Rails::VERSION::MAJOR < 5
+  if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR < 5
     def test_uses_original_exception_class_name
       orig = FooError.new
       e = mock('exception', original_exception: orig)


### PR DESCRIPTION
This PR is made on top of #269, however that one changed the `defined?` check in just one place.  I have adapted it everywhere where it seemed to make sense.