### PR TITLE
Use lazy load hooks to hook on ActionController::Base

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails5/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails5/action_controller.rb
@@ -21,13 +21,12 @@ DependencyDetection.defer do
   end
 
   executes do
-    ActiveSupport.on_load(:action_controller) do |c|
-      c.include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+    ActiveSupport.on_load(:action_controller) do
+      include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+      NewRelic::Agent::PrependSupportability.record_metrics_for(self)
     end
 
     NewRelic::Agent::Instrumentation::ActionControllerSubscriber \
       .subscribe(/^process_action.action_controller$/)
-
-    NewRelic::Agent::PrependSupportability.record_metrics_for(::ActionController::Base, ::ActionController::API)
   end
 end


### PR DESCRIPTION
👋 

Use lazy load hooks to hook on ActionController::Base

- Calling directly ActionController::Base affects the initialization process (one of them being one that controls ActionController configuration)
- As a result setting configuration inside an initializer (such as the asset_host), doesn't have any effect

cc/ @rafaelfranca @haani