### PR TITLE
Fix test errors caused by 585f07e

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_5.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_5.rb
@@ -79,12 +79,11 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent::PrependSupportability.record_metrics_for(::ActiveRecord::Base, ::ActiveRecord::Relation)
-
     ActiveSupport::Notifications.subscribe('sql.active_record',
       NewRelic::Agent::Instrumentation::ActiveRecordSubscriber.new)
 
     ActiveSupport.on_load(:active_record) do
+      ::NewRelic::Agent::PrependSupportability.record_metrics_for(::ActiveRecord::Base, ::ActiveRecord::Relation)
       ::ActiveRecord::Base.prepend ::NewRelic::Agent::Instrumentation::ActiveRecord::BaseExtensions
       ::ActiveRecord::Relation.prepend ::NewRelic::Agent::Instrumentation::ActiveRecord::RelationExtensions
     end


### PR DESCRIPTION
When upgrading to use `newrelic_rpm` version 4.5.0.337 our unit tests result in a large number of errors mostly like:

```
ActiveRecord::RecordInvalid: Validation failed: Branch must exist
```

There are a few others but this error is by far the largest in number. I have identified the commit that causes this (https://github.com/newrelic/rpm/commit/704fe528c245b90acfd71358a6b3928b8076372e) and I notice that the code that is moved from the end to the start of the block is also moved outside of the `ActiveSupport.on_load(:active_record) do` block. These lines have subsequently been changed into a single line:

```
::NewRelic::Agent::PrependSupportability.record_metrics_for(::ActiveRecord::Base, ::ActiveRecord::Relation)
```

If I move this back inside the `on_load` block then all our tests run without error.

I am raising a PR as I am unable to create an issue. I realise that this may not be a complete fix as other things may be affected but it prevents the test errors we are seeing so it is at least moving towards a fix.