### PR TITLE
Call `::NewRelic::Agent::PrependSupportability.record_metrics_for` in `ActiveSupport.on_load`

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_5.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_5.rb
@@ -79,12 +79,11 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent::PrependSupportability.record_metrics_for(::ActiveRecord::Base, ::ActiveRecord::Relation)
-
     ActiveSupport::Notifications.subscribe('sql.active_record',
       NewRelic::Agent::Instrumentation::ActiveRecordSubscriber.new)
 
     ActiveSupport.on_load(:active_record) do
+      ::NewRelic::Agent::PrependSupportability.record_metrics_for(::ActiveRecord::Base, ::ActiveRecord::Relation)
       ::ActiveRecord::Base.prepend ::NewRelic::Agent::Instrumentation::ActiveRecord::BaseExtensions
       ::ActiveRecord::Relation.prepend ::NewRelic::Agent::Instrumentation::ActiveRecord::RelationExtensions
     end


### PR DESCRIPTION
I think this gem(4.5.0.337 and 4.6.0.338) breaks `ActiveRecord` configuration in Rails 5.0.x. Because it does not hook `ActiveRecord` correctly.

Rails 5.1.x does not have this problem. Because [load_defaults](https://github.com/rails/rails/blob/5-1-stable/railties/lib/rails/application/configuration.rb#L57-L83) method is called in `config/application.rb` before this gem is loaded.

I think Rails 4 looks fine because it hooks correctly.
https://github.com/newrelic/rpm/blob/35cb1eea0d9301d30bc5cd7aad63f8a332cdad1a/lib/new_relic/agent/instrumentation/active_record_4.rb#L30

Related to: https://github.com/rails/rails/issues/23589

---

Example

```
rails _5.0.6_ new ArHookBug
cd ArHookBug
rails g scaffold user name:string
rails g scaffold profile user:references address:string
rails db:migrate
rails s

# Open http://localhost:3000/profiles/new
# Click `Create Profile`
# You can't create a user because `User must exist`. This is correct.

echo "gem 'newrelic_rpm'" >> Gemfile
bundle
rails s

# Open http://localhost:3000/profiles/new
# Click `Create Profile`
# You can create a user, but it shouldn't.
```
