### PR TITLE
Initialize NewRelic before Rails' config-initializers

### DIFF
--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -37,7 +37,7 @@ elsif defined?(Rails::VERSION)
     module NewRelic
       class Railtie < Rails::Railtie
 
-        initializer "newrelic_rpm.start_plugin" do |app|
+        initializer "newrelic_rpm.start_plugin", before: :load_config_initializers do |app|
           NewRelic::Control.instance.init_plugin(:config => app.config)
         end
       end

--- a/test/multiverse/suites/sidekiq/test_worker.rb
+++ b/test/multiverse/suites/sidekiq/test_worker.rb
@@ -2,6 +2,8 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
+require_relative "sidekiq_server"
+
 class TestWorker
   include Sidekiq::Worker
 


### PR DESCRIPTION
Before, the initializer for NewRelic did not specify any ordering. In some situations, Rails will order its `load_config_initializers` before NewRelic's `newrelic_rpm.start_plugin`. This is a problem if NewRelic is called in a config-initializer (e.g. when defining method tracers) and will output the following warning:

```
Agent unavailable as it hasn't been started.
```

This change ensures that `newrelic_rpm.start_plugin` always gets loaded before config-intiializers are.

The problem is detailed and the fix is demonstrated here: https://github.com/tonyta/newrelic_warning/pull/1

---

An unrelated dependency loading issue is fixed in https://github.com/newrelic/rpm/pull/279/commits/cc9f74a53c1f2f3d9a4d05a48418b15dfcf22952 to allow tests to pass.