### PR TITLE
Remove type attribute from script tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ If you can't find what you're looking for there, reach out to us on our [support
 site](http://support.newrelic.com/) or our [community forum](http://forum.newrelic.com)
 and we'll be happy to help you.
 
-Also available is community support on IRC: we generally use #newrelic
-on irc.freenode.net
-
 Find a bug? Contact us via [support.newrelic.com](http://support.newrelic.com/),
 or email support@newrelic.com.
 

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -104,7 +104,7 @@ module NewRelic
       end
 
       def browser_timing_loader
-        html_safe_if_needed("\n<script type=\"text/javascript\">#{Agent.config[:js_agent_loader]}</script>")
+        html_safe_if_needed("\n<script>#{Agent.config[:js_agent_loader]}</script>")
       end
 
       def browser_timing_config(state)
@@ -114,7 +114,7 @@ module NewRelic
         txn.freeze_name_and_execute_if_not_ignored do
           data = data_for_js_agent(state)
           json = ::JSON.dump(data)
-          return html_safe_if_needed("\n<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info=#{json}</script>")
+          return html_safe_if_needed("\n<script>window.NREUM||(NREUM={});NREUM.info=#{json}</script>")
         end
 
         ''

--- a/test/new_relic/agent/javascript_instrumentor_test.rb
+++ b/test/new_relic/agent/javascript_instrumentor_test.rb
@@ -292,11 +292,11 @@ class NewRelic::Agent::JavascriptInstrumentorTest < Minitest::Test
 
   # Helpers
 
-  BEGINNING_OF_FOOTER = '<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info='
+  BEGINNING_OF_FOOTER = '<script>window.NREUM||(NREUM={});NREUM.info='
   END_OF_FOOTER = '}</script>'
 
   def assert_has_js_agent_loader(header)
-    assert_match(%Q[\n<script type=\"text/javascript\">loader</script>],
+    assert_match(%Q[\n<script>loader</script>],
                  header,
                  "expected new JS agent loader 'loader' but saw '#{header}'")
   end

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -192,7 +192,7 @@ EOL
       "Content-Type"   => "text/html"
     }
     headers = headers_from_request(original_headers, "<html><body></body></html>")
-    assert_equal "390", headers["Content-Length"]
+    assert_equal "344", headers["Content-Length"]
   end
 
   def headers_from_request(headers, content)


### PR DESCRIPTION
`type="text/javascript"` is optional for the `<script>` tag.

The [W3C Validator](https://validator.w3.org) reports the following results:
```
Warning: The `type` attribute is unnecessary for JavaScript resources.
```