### PR TITLE
Add webpacker:compile to blacklisted tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ If you can't find what you're looking for there, reach out to us on our [support
 site](http://support.newrelic.com/) or our [community forum](http://forum.newrelic.com)
 and we'll be happy to help you.
 
-Also available is community support on IRC: we generally use #newrelic
-on irc.freenode.net
-
 Find a bug? Contact us via [support.newrelic.com](http://support.newrelic.com/),
 or email support@newrelic.com.
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -238,7 +238,8 @@ module NewRelic
         'test:uncommitted',
         'time:zones:all',
         'tmp:clear',
-        'tmp:create'
+        'tmp:create',
+        'webpacker:compile'
       ].join(',').freeze
 
       DEFAULTS = {


### PR DESCRIPTION
Webpacker ships with Rails 5 and the task of compiling assets with webpack is pretty common.
Just like `assets:precompile` is a member of `AUTOSTART_BLACKLISTED_RAKE_TASKS`,
I suggest that `webpacker:compile` should be as well