### PR TITLE
Enable users to customize attributes sent to transaction tracer.

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -26,8 +26,14 @@ DependencyDetection.defer do
           self.class.default_trace_args(msg)
         end
 
+        attributes = if worker.respond_to?(:newrelic_attributes)
+                       worker.newrelic_attributes(msg['args'])
+                     else
+                       msg['args']
+                     end
+
         perform_action_with_newrelic_trace(trace_args) do
-          NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(msg['args'], :'job.sidekiq.args',
+          NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(attributes, :'job.sidekiq.args',
             NewRelic::Agent::AttributeFilter::DST_NONE)
 
           yield


### PR DESCRIPTION
## The problem

There are some cases that the size of the job argument is a big data structure.

Example:

Let's say that your worker process 1000 mailing events per execution.

```ruby
class MailingEvent::Processor
  include Sidekiq::Worker

  def perform(events)
    ....
  end
end
```
Now, if you want to analyze this worker with Transaction Tracer the page freezes trying to load all attributes.

 ## Solution

This PR enables users to customize these attributes. example:

```ruby
class MailingEvent::ProcessorWorker
  include Sidekiq::Worker

  def perform(events)
    ....
  end

  def newrelic_attibutes(args)
    {
       number_of_items: args.first.count
    }
  end
end
```


