### PR TITLE
Use Delayed::Job#display_name when available

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -761,6 +761,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If <code>true</code>, disables the use of GC::Profiler to measure time spent in garbage collection'
         },
+        :'delayed_job.use_display_name' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'Use Delayed::Job#display_name for naming transactions.'
+        },
         :'sidekiq.capture_params' => {
           :default => false,
           :public => true,

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -21,7 +21,11 @@ module NewRelic
             if payload_object.is_a? ::Delayed::PerformableMethod
               # payload_object contains a reference to an object
               # that received an asynchronous method call via .delay or .handle_asynchronously
-              "#{object_name(payload_object)}#{delimiter(payload_object)}#{method_name(payload_object)}"
+              if payload_object.respond_to?(:display_name)
+                payload_object.display_name
+              else
+                "#{object_name(payload_object)}#{delimiter(payload_object)}#{method_name(payload_object)}"
+              end
             else
               # payload_object is a user-defined job enqueued via Delayed::Job.enqueue
               payload_object.class.name

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -21,7 +21,7 @@ module NewRelic
             if payload_object.is_a? ::Delayed::PerformableMethod
               # payload_object contains a reference to an object
               # that received an asynchronous method call via .delay or .handle_asynchronously
-              if payload_object.respond_to?(:display_name)
+              if NewRelic::Agent.config[:'delayed_job.use_display_name']
                 payload_object.display_name
               else
                 "#{object_name(payload_object)}#{delimiter(payload_object)}#{method_name(payload_object)}"


### PR DESCRIPTION
Hi!

This method is available already for 9 years: https://github.com/collectiveidea/delayed_job/blame/master/lib/delayed/performable_method.rb#L17

I can remove fallback to custom implementation if it works for you.

Actually I want this changes, because we have some patches for delayed job, which modify `display_name` as well.