### PR TITLE
Fix the community forum url

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can find more detailed documentation [on our website](http://newrelic.com/do
 and specifically in the [Ruby category](http://newrelic.com/docs/ruby).
 
 If you can't find what you're looking for there, reach out to us on our [support
-site](http://support.newrelic.com/) or our [community forum](http://forum.newrelic.com)
+site](http://support.newrelic.com/) or our [community forum](https://discuss.newrelic.com/)
 and we'll be happy to help you.
 
 Find a bug? Contact us via [support.newrelic.com](http://support.newrelic.com/),


### PR DESCRIPTION
The URL listed in the README doesn't appear to be valid anymore, updated to point to the one linked on https://newrelic.com