### PR TITLE
Truncate backtraces over 1MB

### DIFF
--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -249,8 +249,10 @@ class NewRelic::Agent::ErrorCollectorTest < Minitest::Test
   end
 
   def test_short_trace_not_truncated
-    trace = @error_collector.truncate_trace(['error', 'error', 'error'], 6)
-    assert_equal trace.length, 3
+    fake_trace = ['error1', 'error2', 'error3', 'error4']
+    bytes = fake_trace.inject(0) { |sum, frame| sum += frame.bytesize }
+    trace = @error_collector.truncate_trace(fake_trace, bytes + 1)
+    assert_equal trace.length, 4
   end
 
   def test_empty_trace_not_truncated
@@ -258,14 +260,11 @@ class NewRelic::Agent::ErrorCollectorTest < Minitest::Test
     assert_equal trace.length, 0
   end
 
-  def test_keeps_correct_frames_if_keep_frames_is_even
-    trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'], 2)
+  def test_keeps_correct_number_of_frames
+    fake_trace = ['error1', 'error2', 'error3', 'error4']
+    bytes = fake_trace.inject(0) { |sum, frame| sum += frame.bytesize }
+    trace = @error_collector.truncate_trace(fake_trace, (bytes / 2))
     assert_equal ['error1', '<truncated 2 additional frames>', 'error4'], trace
-  end
-
-  def test_keeps_correct_frames_if_keep_frames_is_odd
-    trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'], 3)
-    assert_equal ['error1', 'error2', '<truncated 1 additional frames>', 'error4'], trace
   end
 
   if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR < 5


### PR DESCRIPTION
The current backtrace truncate logic currently removes important frames in the backtrace on larger applications (multiple middlewares, callbacks, gems, etc). This bit me pretty hard when I was trying to debug an app that was on fire but I was missing important frames from the backtrace in the error logs in APM.

I spoke with support about this and they informed me that I could monkey patch the gem so that it supports larger stack traces so we do not lose important information. They told me that stack traces over 1MB will be dropped by the APM API.

This PR removes the backtrace frame cap and limits overall size of the backtrace to 1MB. Like the previous implementation it removes the middle of the backtrace since that's where you're most likely to see an infinite loop or something anyway.

I updated the tests and I think I got everything working but if you need more to make this happen, lemme know and I'll get it done.