### PR TITLE
Make max_backtrace_frames configurable

### DIFF
--- a/config.dot
+++ b/config.dot
@@ -18,6 +18,7 @@ digraph AgentEnabled {
   "[error_collector.capture_source]"
   "[error_collector.enabled]"
   "[error_collector.ignore_errors]"
+  "[error_collector.max_backtrace_frames]"
   "[browser_monitoring.auto_instrument]"
   "[license_key]"
   "[verify_certificate]"

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -981,6 +981,13 @@ module NewRelic
           :allowed_from_server => true,
           :description => 'Specify a comma-delimited list of error classes that the agent should ignore.'
         },
+        :'error_collector.max_backtrace_frames' => {
+          :default => 50,
+          :public => true,
+          :type => Integer,
+          :allowed_from_server => true,
+          :description => 'Defines the maximum number of frames in an error back trace. Backtraces over this amount are truncated.'
+        },
         :'error_collector.capture_events' => {
           :default => value_of(:'error_collector.enabled'),
           :public => true,

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -13,9 +13,6 @@ module NewRelic
       # made configurable in the future. This is a tradeoff between
       # memory and data retention
       MAX_ERROR_QUEUE_LENGTH = 20
-      # Maximum number of frames in backtraces. May be made configurable
-      # in the future.
-      MAX_BACKTRACE_FRAMES = 50
       EXCEPTION_TAG_IVAR = :'@__nr_seen_exception'
 
       attr_reader :error_trace_aggregator, :error_event_aggregator
@@ -216,7 +213,8 @@ module NewRelic
         nil
       end
 
-      def truncate_trace(trace, keep_frames=MAX_BACKTRACE_FRAMES)
+      def truncate_trace(trace, keep_frames=nil)
+        keep_frames ||= Agent.config[:'error_collector.max_backtrace_frames']
         return trace if trace.length < keep_frames || trace.length == 0
 
         # If keep_frames is odd, we will split things up favoring the top of the trace

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -248,6 +248,13 @@ class NewRelic::Agent::ErrorCollectorTest < Minitest::Test
     assert_equal('<no stack trace>', @error_collector.extract_stack_trace(Exception.new))
   end
 
+  def test_trace_truncated_with_config
+    with_config(:'error_collector.max_backtrace_frames' => 2) do
+      trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'])
+      assert_equal ['error1', '<truncated 2 additional frames>', 'error4'], trace
+    end
+  end
+
   def test_short_trace_not_truncated
     trace = @error_collector.truncate_trace(['error', 'error', 'error'], 6)
     assert_equal trace.length, 3


### PR DESCRIPTION
This makes max_backtrace_frames configurable via YAML and other agent config stuff instead of hardcoding it to 50 frames.

This is in response to feedback I got on #289.

Notes:

1. Default number of frames is still 50
2. I left the ability to override the number of frames in the truncate method's parameters. Since this is now configurable, I was going to change the tests over to just use the config but I wasn't sure if there was something else that was relying on that.

If you'd like me to, I can remove the parameter override and just update the tests to use `with_config` to make sure the coverage is the same.

Please let me know if there are additional changes or tests needed to get this in.