### PR TITLE
Fix Sequel deferring

### DIFF
--- a/lib/new_relic/agent/instrumentation/sequel.rb
+++ b/lib/new_relic/agent/instrumentation/sequel.rb
@@ -38,7 +38,7 @@ DependencyDetection.defer do
         db.extension :newrelic_instrumentation
       end
 
-      Sequel::Model.plugin :newrelic_instrumentation
+      Sequel::Model.plugin(:newrelic_instrumentation) if defined?(Sequel::Model)
     else
 
       NewRelic::Agent.logger.info "Sequel instrumentation requires at least version 3.37.0."


### PR DESCRIPTION
Sequel may be loaded as a core without `Sequel::Model` module. In that case requiring `newrelic_rpm` will fail on setup Sequel model plugin. This patch prevents it and adds an ability to load an extension only.