### PR TITLE
Add grape 1.2+ support

### DIFF
--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -1,7 +1,11 @@
 versions = %w(0.17.0 0.16.2 0.15.0 0.14.0 0.13.0 0.12.0 0.11.0 0.10.0 0.9.0 0.8.0 0.7.0 0.6.1 0.5.0 0.4.1 0.3.2 0.2.6 0.2.0 0.1.5)
 versions.unshift '0.18.0' if RUBY_VERSION >= '2.1.0'
-versions.unshift '0.19.2' if RUBY_VERSION >= '2.2.0'
-versions.unshift '1.0.2' if RUBY_VERSION >= '2.2.0'
+if RUBY_VERSION >= '2.2.0'
+  versions.unshift '0.19.2'
+  versions.unshift '1.0.2'
+  versions.unshift '1.1.0'
+  versions.unshift '1.2.0'
+end
 
 rack_test_version = RUBY_VERSION < "2.2.0" ? "< 0.8.0" : ">= 0.8.0"
 


### PR DESCRIPTION
Hello maintainers. 

I hope you would have a look at this when you have time because our team is facing a problem that we can't see detailed metrics in the New Relic web. 🙏 

## Problem

In short, `newrelic_rpm` does not work with `grape` v1.2.0 or posterior. I could see only metrics for `Foo#call` methods in the dashboard. It seems that the agent fails to track environments.

![image](https://user-images.githubusercontent.com/1811616/50501951-33fff100-0a9f-11e9-9a0b-1377e215add7.png)

**My environment**

- newrelic_rpm 5.6.0.349
- grape 1.2.2
   - 📝 When I tried to downgrade `grape` to `1.1.0`, it worked well.
- rails 4.2.9 (Seems nothing relevant to this problem)
- Ruby 2.5.0 (Seems nothing relevant to this problem)

## Cause

`grape` 1.2.0 brought some breaking changes and it affects `newrelic_rpm`. Those changes are the two below.

1. The class `Grape::API` no longer refers to an API instance, rather, what used to be `Grape::API` is `Grape::API::Instance`
2. How to get the class name is changed. `name` => `base.name`

ref: https://github.com/ruby-grape/grape/blob/c20a73ac1e3f3ba1082005ed61bf69452373ba87/UPGRADING.md#upgrading-to--120

## Solution

I just made a patch around `::NewRelic::Agent::Instrumentation::GrapeInstrumentation` to follow the changes.

## Testing

At first, I confirmed `grape` v1.2.0 breaks the latest `newrelic_rpm`:

1. I just tweaked `test/multiverse/suites/grape/Envfile` so that it executes tests against `grape` v1.2.0.
2. I run `bundle exec rake test:multiverse[grape]`.
   - Tests against `1.2.0` failed. (There were too long logs that I wasn't able to paste them here.)

Next, I made a change to `lib/new_relic/agent/instrumentation/grape.rb`, and then I run `bundle exec rake test:multiverse[grape]` again. The tests passed now!

At last, I tested my forked version so that I could confirm it would wholly work well.

1. I added `gem 'newrelic_rpm', git: 'https://github.com/ohbarye/rpm.git', branch: 'grape-1.2'` into my Gemfile, then run `bundle install`.
   - Of course, I kept other library versions as is. (grape 1.2.0 etc.)
2. I deployed the Rails application and manipulated so that it sends metrics to NewRelic.
   - Finally, I was able to see the detailed metrics like below. That's what I wanted.

![image](https://user-images.githubusercontent.com/1811616/50502347-efc22000-0aa1-11e9-8ca3-ad6939c83ee0.png)
