### PR TITLE
Fix bunny support for when pop does not return a message

### DIFF
--- a/lib/new_relic/agent/instrumentation/bunny.rb
+++ b/lib/new_relic/agent/instrumentation/bunny.rb
@@ -62,13 +62,14 @@ DependencyDetection.defer do
           begin
             if !delivery_info.nil?
               exchange_name = NewRelic::Agent::Instrumentation::Bunny.exchange_name(delivery_info.exchange)
+              exchange_type = NewRelic::Agent::Instrumentation::Bunny.exchange_type(delivery_info, channel)
 
               segment = NewRelic::Agent::Messaging.start_amqp_consume_segment(
                 library: NewRelic::Agent::Instrumentation::Bunny::LIBRARY,
                 destination_name: exchange_name,
                 delivery_info: delivery_info,
                 message_properties: message_properties,
-                exchange_type: channel.exchanges[msg.first.exchange].type,
+                exchange_type: exchange_type,
                 queue_name: name,
                 start_time: t0
               )

--- a/test/multiverse/suites/rabbitmq/bunny_test.rb
+++ b/test/multiverse/suites/rabbitmq/bunny_test.rb
@@ -287,6 +287,27 @@ class BunnyTest < Minitest::Test
     end
   end
 
+  def test_pop_returning_a_good_message_send_to_an_exchange_we_havent_accessed_doesnt_error
+    NewRelic::Agent.stubs(:logger).returns(NewRelic::Agent::MemoryLogger.new)
+
+    with_queue do |queue|
+      # publish in such a way that the exchange object does not end up in channel.exchanges
+      channel = queue.channel
+      channel.basic_publish("test_msg", "", queue.name)
+
+      assert_empty channel.exchanges
+
+      in_transaction "test_txn" do
+        msg = queue.pop
+        assert_equal "test_msg", msg[2]
+      end
+
+      assert_empty NewRelic::Agent.logger.messages #.reject { |m| m.first == :debug }
+
+      assert_metrics_recorded ["MessageBroker/RabbitMQ/Exchange/Consume/Named/Default"]
+    end
+  end
+
   def with_queue temp=true, exclusive=true, &block
     queue_name = temp ? "" : random_string
     queue = @chan.queue(queue_name, exclusive: exclusive)

--- a/test/multiverse/suites/rabbitmq/bunny_test.rb
+++ b/test/multiverse/suites/rabbitmq/bunny_test.rb
@@ -275,6 +275,18 @@ class BunnyTest < Minitest::Test
     end
   end
 
+  def test_pop_returning_no_message_doesnt_error
+    NewRelic::Agent.stubs(:logger).returns(NewRelic::Agent::MemoryLogger.new)
+
+    with_queue do |queue|
+      in_transaction "test_txn" do
+        queue.pop
+      end
+
+      assert_empty NewRelic::Agent.logger.messages
+    end
+  end
+
   def with_queue temp=true, exclusive=true, &block
     queue_name = temp ? "" : random_string
     queue = @chan.queue(queue_name, exclusive: exclusive)


### PR DESCRIPTION
Currently, if pop a message results in no message (because the queue is 
empty), an error is logged because of a NoMethodError on nil:NilClass. 
This fixes it by skipping recording the segment if no message was 
returned.

I'm not sure if the skip is the correct solution, but it makes it so the log file isn't filled with errors when you do a lot of pops against empty queues.