### PR TITLE
Improve ActiveRecord connection resolution performance

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1235,6 +1235,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'Controls whether to normalize string encodings prior to serializing data for the collector to JSON.'
         },
+        :backport_fast_active_record_connection_lookup => {
+          :default => true,
+          :public => false,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'Enables patching of "sql.active_record" AS Notification to include :connection in payload.'
+        },
         :disable_vm_sampler => {
           :default      => false,
           :public       => true,

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -3,7 +3,6 @@
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
 require 'new_relic/agent/instrumentation/active_record_prepend'
-require 'new_relic/agent/instrumentation/active_record_notifications'
 
 module NewRelic
   module Agent
@@ -30,13 +29,6 @@ module NewRelic
           end
 
           ::ActiveRecord::ConnectionAdapters::AbstractAdapter.module_eval do
-            if ::ActiveRecord::VERSION::MAJOR.to_i == 4 && ::ActiveRecord::VERSION::MINOR.to_i >= 1
-              include ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions41
-            elsif ::ActiveRecord::VERSION::MAJOR.to_i == 5 && ::ActiveRecord::VERSION::MINOR.to_i == 0
-              include ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions50
-            elsif ::ActiveRecord::VERSION::MAJOR.to_i == 5 && ::ActiveRecord::VERSION::MINOR.to_i >= 1
-              include ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions51
-            end
             include ::NewRelic::Agent::Instrumentation::ActiveRecord
           end
         end

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -3,6 +3,7 @@
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
 require 'new_relic/agent/instrumentation/active_record_prepend'
+require 'new_relic/agent/instrumentation/active_record_notifications'
 
 module NewRelic
   module Agent
@@ -29,6 +30,13 @@ module NewRelic
           end
 
           ::ActiveRecord::ConnectionAdapters::AbstractAdapter.module_eval do
+            if ::ActiveRecord::VERSION::MAJOR.to_i == 4 && ::ActiveRecord::VERSION::MINOR.to_i >= 1
+              include ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions41
+            elsif ::ActiveRecord::VERSION::MAJOR.to_i == 5 && ::ActiveRecord::VERSION::MINOR.to_i == 0
+              include ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions50
+            elsif ::ActiveRecord::VERSION::MAJOR.to_i == 5 && ::ActiveRecord::VERSION::MINOR.to_i >= 1
+              include ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions51
+            end
             include ::NewRelic::Agent::Instrumentation::ActiveRecord
           end
         end

--- a/lib/new_relic/agent/instrumentation/active_record_4.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_4.rb
@@ -39,7 +39,9 @@ DependencyDetection.defer do
         ::NewRelic::Agent::Instrumentation::ActiveRecordHelper.instrument_additional_methods
       end
 
-      ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions41
+      if NewRelic::Agent.config[:backport_fast_active_record_connection_lookup]
+        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions41
+      end
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/active_record_4.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_4.rb
@@ -2,6 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
+require 'new_relic/agent/instrumentation/active_record_notifications'
 require 'new_relic/agent/instrumentation/active_record_prepend'
 require 'new_relic/agent/instrumentation/active_record_subscriber'
 require 'new_relic/agent/prepend_supportability'
@@ -37,6 +38,8 @@ DependencyDetection.defer do
       else
         ::NewRelic::Agent::Instrumentation::ActiveRecordHelper.instrument_additional_methods
       end
+
+      ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions41
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/active_record_4.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_4.rb
@@ -39,7 +39,7 @@ DependencyDetection.defer do
         ::NewRelic::Agent::Instrumentation::ActiveRecordHelper.instrument_additional_methods
       end
 
-      ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions41
+      ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions41
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/active_record_5.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_5.rb
@@ -39,9 +39,9 @@ DependencyDetection.defer do
       end
 
       if ::ActiveRecord::VERSION::MINOR.to_i == 0
-        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions50
+        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
       elsif ::ActiveRecord::VERSION::MINOR.to_i >= 1
-        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions51
+        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions51
       end
     end
   end

--- a/lib/new_relic/agent/instrumentation/active_record_5.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_5.rb
@@ -38,10 +38,12 @@ DependencyDetection.defer do
         ::ActiveRecord::Base.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions516
       end
 
-      if ::ActiveRecord::VERSION::MINOR.to_i == 0
-        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
-      elsif ::ActiveRecord::VERSION::MINOR.to_i >= 1
-        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions51
+      if NewRelic::Agent.config[:backport_fast_active_record_connection_lookup]
+        if ::ActiveRecord::VERSION::MINOR.to_i == 0
+          ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
+        elsif ::ActiveRecord::VERSION::MINOR.to_i >= 1
+          ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions51
+        end
       end
     end
   end

--- a/lib/new_relic/agent/instrumentation/active_record_5.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_5.rb
@@ -2,6 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
+require 'new_relic/agent/instrumentation/active_record_notifications'
 require 'new_relic/agent/instrumentation/active_record_subscriber'
 require 'new_relic/agent/instrumentation/active_record_prepend'
 
@@ -35,6 +36,12 @@ DependencyDetection.defer do
       if ::ActiveRecord::VERSION::MINOR.to_i == 1 &&
          ::ActiveRecord::VERSION::TINY.to_i >= 6
         ::ActiveRecord::Base.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions516
+      end
+
+      if ::ActiveRecord::VERSION::MINOR.to_i == 0
+        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions50
+      elsif ::ActiveRecord::VERSION::MINOR.to_i >= 1
+        ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordNotitifcations::BaseExtensions51
       end
     end
   end

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -1,0 +1,65 @@
+# Provides a way to send :connection through ActiveSupport notifications to avoid
+# looping through connection handlers to locate a connection by connection_id
+# This is not needed in Rails 6+: https://github.com/rails/rails/pull/34602
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      module ActiveRecordNotifications
+        module BaseExtensions41
+          # https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L371
+          def log(sql, name = "SQL", binds = [], statement_name = nil)
+            @instrumenter.instrument(
+              "sql.active_record",
+              :sql            => sql,
+              :name           => name,
+              :connection_id  => object_id,
+              :connection     => self,
+              :statement_name => statement_name,
+              :binds          => binds) { yield }
+          rescue => e
+            raise translate_exception_class(e, sql)
+          end
+        end
+
+        module BaseExtensions50
+          # https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L582
+          def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
+            @instrumenter.instrument(
+              "sql.active_record",
+              sql:               sql,
+              name:              name,
+              binds:             binds,
+              type_casted_binds: type_casted_binds,
+              statement_name:    statement_name,
+              connection_id:     object_id,
+              connection:        self) { yield }
+          rescue => e
+            raise translate_exception_class(e, sql)
+          end
+        end
+
+        module BaseExtensions51
+          # https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L603
+          def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil) # :doc:
+            @instrumenter.instrument(
+              "sql.active_record",
+              sql:               sql,
+              name:              name,
+              binds:             binds,
+              type_casted_binds: type_casted_binds,
+              statement_name:    statement_name,
+              connection_id:     object_id,
+              connection:        self) do
+                @lock.synchronize do
+                  yield
+                end
+              end
+          rescue => e
+            raise translate_exception_class(e, sql)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -81,7 +81,7 @@ module NewRelic
           # handle if the notification payload provides the AR connection
           # available in Rails 6+ & our ActiveRecordNotifications#log extension
           if payload[:connection]
-            connection_config = connection.instance_variable_get(:@config)
+            connection_config = payload[:connection].instance_variable_get(:@config)
             return connection_config if connection_config
           end
 

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -78,6 +78,13 @@ module NewRelic
         def active_record_config(payload)
           return unless payload[:connection_id]
 
+          # handle if the notification payload provides the AR connection
+          # available in Rails 6+ & our ActiveRecordNotifications#log extension
+          if payload[:connection]
+            connection_config = connection.instance_variable_get(:@config)
+            return connection_config if connection_config
+          end
+
           connection = nil
           connection_id = payload[:connection_id]
 


### PR DESCRIPTION
Looping through connection handlers and connections can be a performance hit due to duping involved on the underlying thread safe call from `connection_pool_list` to `ThreadSafe::Cache#values`. Underneath `#values` dupes the connection list per each call which can add up.

This backports in an [improvement](https://github.com/rails/rails/pull/34602) that was introduced in Rails 6 that passes through the connection in the notification payload.

StackProf:

```
NewRelic::Agent::Instrumentation::ActiveRecordSubscriber#active_record_config (/usr/local/bundle/gems/newrelic_rpm-4.6.0.338/lib/new_relic/agent/instrumentation/active_record_subscriber.rb:78)
  samples:     9 self (0.1%)  /    167 total (1.4%)
  callers:
     167  (  100.0%)  NewRelic::Agent::Instrumentation::ActiveRecordSubscriber#start
       7  (    4.2%)  NewRelic::Agent::Instrumentation::ActiveRecordSubscriber#active_record_config
  callees (158 total):
     147  (   93.0%)  ActiveRecord::ConnectionAdapters::ConnectionHandler#connection_pool_list
      10  (    6.3%)  ActiveRecord::Base.connection_handler
       7  (    4.4%)  NewRelic::Agent::Instrumentation::ActiveRecordSubscriber#active_record_config
       1  (    0.6%)  AutoReplica::ConnectionHandler#method_missing
  code:
                                  |    78  |         def active_record_config(payload)
                                  |    79  |           return unless payload[:connection_id]
                                  |    80  |
                                  |    81  |           connection = nil
                                  |    82  |           connection_id = payload[:connection_id]
                                  |    83  |
  162    (1.3%)                   |    84  |           ::ActiveRecord::Base.connection_handler.connection_pool_list.each do |handler|
    3    (0.0%)                   |    85  |             connection = handler.connections.detect do |conn|
    3    (0.0%) /     3   (0.0%)  |    86  |               conn.object_id == connection_id
                                  |    87  |             end
                                  |    88  |
    1    (0.0%) /     1   (0.0%)  |    89  |             break if connection
                                  |    90  |           end
                                  |    91  |
    5    (0.0%) /     5   (0.0%)  |    92  |           connection.instance_variable_get(:@config) if connection
                                  |    93  |         end
```

Happy to take pointers on where best to add tests.