### PR TITLE
Convert value of Socket.gethostname to UTF-8

### DIFF
--- a/lib/new_relic/agent/hostname.rb
+++ b/lib/new_relic/agent/hostname.rb
@@ -13,7 +13,7 @@ module NewRelic
           dyno_name = "#{matching_prefix}.*" if matching_prefix
           dyno_name
         else
-          Socket.gethostname
+          Socket.gethostname.force_encoding(Encoding::UTF_8)
         end
       end
 

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -21,6 +21,11 @@ module NewRelic
         assert_equal 'Rivendell', NewRelic::Agent::Hostname.get
       end
 
+      def test_get_returns_socket_hostname_converted_to_utf8
+        Socket.stubs(:gethostname).returns('Elronds’s-Computer'.force_encoding(Encoding::ASCII_8BIT))
+        assert_equal 'Elronds’s-Computer', NewRelic::Agent::Hostname.get
+      end
+
       def test_get_uses_dyno_name_if_dyno_env_set_and_dyno_names_enabled
         with_dyno_name('Imladris', :'heroku.use_dyno_names' => true) do
           assert_equal 'Imladris', NewRelic::Agent::Hostname.get


### PR DESCRIPTION
I was getting a lot of warnings locally that looked like this:
`log writing failed. "\xE2" from ASCII-8BIT to UTF-8`

After much digging, I traced it down to the agent logger, which uses the computer's hostname in the default log formatter. Turns out `Socket.gethostname` does not respect the default character encoding, and I get ASCII-8BIT every time, even though any new string is UTF-8.

```
2.6.2 :004 > Socket.gethostname.encoding
 => #<Encoding:ASCII-8BIT>
2.6.2 :005 > "".encoding
 => #<Encoding:UTF-8>
```

My computer's name has a special character (curved apostrophe in `Rafael-Petry’s-MacBook-Pro`), which meant all writes to `newrelic_agent.log` failed with the warning mentioned earlier. This change forces the encoding to UTF-8, which fixes the problem.

For reference, prior to the change, the test I added failed with the following message:
```
  1) Failure:
NewRelic::Agent::HostnameTest#test_get_returns_socket_hostname_converted_to_utf8 [test/new_relic/agent/hostname_test.rb:26]:
--- expected
+++ actual
@@ -1 +1 @@
-"Elronds’s-Computer"
+"Elronds\xE2\x80\x99s-Computer"
```