### PR TITLE
Fix ActiveRecord 4 monkey patch to align with the original code

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -13,6 +13,8 @@ module NewRelic
   module Agent
     module Instrumentation
       module ActiveRecordNotifications
+        SQL_ACTIVE_RECORD = 'sql.active_record'.freeze
+
         module BaseExtensions41
           def self.included(base)
             base.class_eval do
@@ -24,7 +26,7 @@ module NewRelic
           # https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L371
           def log_with_performance_improvement(sql, name = "SQL", binds = [], statement_name = nil)
             @instrumenter.instrument(
-              "sql.active_record",
+              SQL_ACTIVE_RECORD,
               :sql            => sql,
               :name           => name,
               :connection_id  => object_id,
@@ -52,7 +54,7 @@ module NewRelic
           # https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L582
           def log_with_performance_improvement(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
             @instrumenter.instrument(
-              "sql.active_record",
+              SQL_ACTIVE_RECORD,
               sql:               sql,
               name:              name,
               binds:             binds,
@@ -76,7 +78,7 @@ module NewRelic
           # https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L603
           def log_with_performance_improvement(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil) # :doc:
             @instrumenter.instrument(
-              "sql.active_record",
+              SQL_ACTIVE_RECORD,
               sql:               sql,
               name:              name,
               binds:             binds,

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -15,7 +15,7 @@ module NewRelic
       module ActiveRecordNotifications
         SQL_ACTIVE_RECORD = 'sql.active_record'.freeze
 
-        module BaseExtensions41
+        module BaseExtensions4x
           def self.included(base)
             base.class_eval do
               alias_method :log_without_performance_improvement, :log
@@ -165,7 +165,7 @@ DependencyDetection.defer do
       minor_version = ::ActiveRecord::VERSION::MINOR.to_i
 
       activerecord_extension = if major_version == 4
-        ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions41
+        ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions4x
       elsif major_version == 5 && minor_version == 0
         ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
       elsif major_version == 5 && minor_version == 1

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -154,15 +154,15 @@ DependencyDetection.defer do
 
   executes do
     if NewRelic::Agent.config[:backport_fast_active_record_connection_lookup]
+      major_version = ::ActiveRecord::VERSION::MAJOR.to_i
+      minor_version = ::ActiveRecord::VERSION::MINOR.to_i
 
-      activerecord_extension = if ::ActiveRecord::VERSION::MAJOR.to_i == 4
+      activerecord_extension = if major_version == 4 && minor_version >= 1
         ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions41
-      elsif ::ActiveRecord::VERSION::MAJOR.to_i == 5
-        if ::ActiveRecord::VERSION::MINOR.to_i == 0
-          ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
-        elsif ::ActiveRecord::VERSION::MINOR.to_i >= 1
-          ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions51
-        end
+      elsif major_version == 5 && minor_version == 0
+        ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
+      elsif major_version == 5 && minor_version == 1
+        ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions51
       end
 
       unless activerecord_extension.nil?

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -32,7 +32,12 @@ module NewRelic
               :statement_name => statement_name,
               :binds          => binds) { yield }
           rescue => e
-            raise translate_exception_class(e, sql)
+            # The translate_exception_class method got introduced in 4.1
+            if ::ActiveRecord::VERSION::MINOR == 0
+              raise translate_exception(e, sql)
+            else
+              raise translate_exception_class(e, sql)
+            end
           end
         end
 
@@ -157,7 +162,7 @@ DependencyDetection.defer do
       major_version = ::ActiveRecord::VERSION::MAJOR.to_i
       minor_version = ::ActiveRecord::VERSION::MINOR.to_i
 
-      activerecord_extension = if major_version == 4 && minor_version >= 1
+      activerecord_extension = if major_version == 4
         ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions41
       elsif major_version == 5 && minor_version == 0
         ::NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -32,7 +32,7 @@ module NewRelic
               :statement_name => statement_name,
               :binds          => binds) { yield }
           rescue => e
-            raise translate_exception(e, sql)
+            raise translate_exception_class(e, sql)
           end
         end
 


### PR DESCRIPTION
Not sure what happened in https://github.com/newrelic/rpm/commit/04b93b3f72fa16fefe14839b999fffdd3f50b8ee, but the original change introducing the performance improvements in AR instrumentation ended up being broken on AR 4 (you lose AR exception messages when the agent is active).

The original version of this monkeypatched line: https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L380