### PR TITLE
Rename event_stack to segment_stack on ActiveStorageSubscriber

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_storage_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_storage_subscriber.rb
@@ -25,11 +25,11 @@ module NewRelic
           segment = Tracer.start_segment name: metric_name(name, payload)
           segment.params[:key] = payload[:key]
           segment.params[:exist] = payload[:exist] if payload.key? :exist
-          event_stack[id].push segment
+          segment_stack[id].push segment
         end
 
         def finish_segment id
-          segment = event_stack[id].pop
+          segment = segment_stack[id].pop
           segment.finish if segment
         end
 


### PR DESCRIPTION
I believe that 0f670cca introduced an error on `ActiveStorageSubscriber`. I'm getting the following error after I updated from version 6.2.0 to 6.4.0.
```
ERROR : NameError: undefined local variable or method 'event_stack' for #<NewRelic::Agent::Instrumentation::ActiveStorageSubscriber:0x0000561d177276f0>
```
