### PR TITLE
RUBY-2226 Remove all versions of bundler before setting up travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 
 language: ruby
 
+dist: precise
 sudo: required
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ language: ruby
 
 dist: precise
 sudo: required
+jdk:
+  - oraclejdk8
 
 before_install:
   # RUBY-2072 Prevent Travis setup failure before our test even starts

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - gem --version
   - ./test/script/before_install/update_rubygems.sh
   - rvm @global do gem uninstall bundler --all --executables || true
+  - gem uninstall bundler --all --executables || true
   - gem install bundler -v=1.17.3
   - ./test/script/before_install/gemstash_mirror.sh
   - bundle --version


### PR DESCRIPTION
Because bundler versions >= 2.0 are problematic for jruby, we must remove them all, then install the correct version.  The existing command to uninstall bundler has been failing on newer travis workers.
running a simple `gem uninstall` without the `rvm @global do...` solves the problem.  