### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -31,6 +31,13 @@ EOS
     "newrelic.yml"
   ]
 
+  s.metadata = {
+    'bug_tracker_uri' => 'https://support.newrelic.com/',
+    'changelog_uri' => 'https://github.com/newrelic/rpm/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://docs.newrelic.com/docs/agents/ruby-agent',
+    'source_code_uri' => 'https://github.com/newrelic/rpm'
+  }
+
   file_list = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/(?!agent_helper.rb)}) }
   build_file_path = 'lib/new_relic/build.rb'
   file_list << build_file_path if File.exist?(build_file_path)


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/newrelic_rpm after the next release.