### PR TITLE
Middleware tracing: add support for streaming responses

### DIFF
--- a/lib/new_relic/agent/instrumentation/middleware_tracing.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_tracing.rb
@@ -103,17 +103,93 @@ module NewRelic
               events.notify(:after_call, env, result)
             end
 
-            result
+            if first_middleware
+              status, headers, response = *result
+              lazy_response = response.respond_to?(:close)
+
+              if lazy_response
+                wrapped_response = StreamBodyProxy.new(response) do
+                  finishable.finish if finishable
+                end
+
+                [status, headers, wrapped_response]
+              else
+                result
+              end
+            else
+              result
+            end
           rescue Exception => e
             NewRelic::Agent.notice_error(e)
             raise e
           ensure
-            finishable.finish if finishable
+            if finishable
+              if first_middleware && lazy_response
+                # NOOP: StreamBodyProxy handles this
+              else
+                finishable.finish
+              end
+            end
           end
         end
 
         def events
           NewRelic::Agent.instance.events
+        end
+      end
+
+      class StreamBodyProxy # ideally this would inherit from < Rack::BodyProxy
+        def initialize(body, &block)
+          @body = body
+          @block = block
+          @closed = false
+        end
+
+        def respond_to?(method_name, include_all = false)
+          case method_name
+          when :to_ary, 'to_ary'
+            return false
+          end
+          super or @body.respond_to?(method_name, include_all)
+        end
+
+        def close
+          return if @closed
+
+          close_segment = NewRelic::Agent::Tracer.start_segment(name: 'Middleware/Rack/StreamBodyProxy/close')
+          @closed = true
+          begin
+            @body.close if @body.respond_to? :close
+          rescue => e
+            NewRelic::Agent.notice_error(e)
+            raise
+          ensure
+            begin
+              close_segment.finish
+            ensure
+              @block.call
+            end
+          end
+        end
+
+        def closed?
+          @closed
+        end
+
+        def each
+          segment = NewRelic::Agent::Tracer.start_segment(name: 'Middleware/Rack/StreamBodyProxy/body_each')
+
+          @body.each { |body| yield body }
+        rescue => e
+          NewRelic::Agent.notice_error(e)
+          raise
+        ensure
+          segment.finish
+        end
+
+        def method_missing(method_name, *args, &block)
+          super if :to_ary == method_name
+          @body.__send__(method_name, *args, &block)
         end
       end
     end


### PR DESCRIPTION
When tracing a request, Newrelic should not stop the transaction if
the response is lazy-evaluated (e.g. Streaming). Rack's Body response
can render streaming responses by wiring an Enumerator into `@body`.
The server that writes to the client then calls response.each which
iterates over each part of the body (parts can be lazy-generated).

We are interested in tracing this code because DB queries, http requests
or other business logic may be running in this Enumerator.