### PR TITLE
Fixup Content-Length setting in rack/browser_monitoring

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -21,6 +21,7 @@ module NewRelic::Rack
 
     CONTENT_TYPE        = 'Content-Type'.freeze
     CONTENT_DISPOSITION = 'Content-Disposition'.freeze
+    CONTENT_LENGTH      = 'Content-Length'.freeze
     ATTACHMENT          = 'attachment'.freeze
     TEXT_HTML           = 'text/html'.freeze
 
@@ -35,6 +36,9 @@ module NewRelic::Rack
       js_to_inject = NewRelic::Agent.browser_timing_header
       if (js_to_inject != "") && should_instrument?(env, status, headers)
         response_string = autoinstrument_source(response, headers, js_to_inject)
+        if headers.key?(CONTENT_LENGTH)
+          headers[CONTENT_LENGTH] = response_string.size.to_s
+        end
 
         env[ALREADY_INSTRUMENTED_KEY] = true
         if response_string

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -2,10 +2,15 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
+begin
+  require 'rack/test'
+rescue LoadError
+  nil
+end
+
 if defined?(::Rack::Test)
 require File.expand_path(File.join(File.dirname(__FILE__),'..', '..',
                                    'test_helper'))
-require 'rack/test'
 require 'new_relic/rack/browser_monitoring'
 
 ENV['RACK_ENV'] = 'test'
@@ -189,7 +194,7 @@ EOL
 
   def test_content_length_set_when_we_modify_source
     original_headers = {
-      "Content-Length" => 0,
+      "Content-Length" => "0",
       "Content-Type"   => "text/html"
     }
     headers = headers_from_request(original_headers, "<html><body></body></html>")


### PR DESCRIPTION
We have an issue with sidekiq web-interface HTML being cut because of wrong `Content-Length` header. Looks like the test is already here, but it's failing, fix it.