### PR TITLE
Reduce allocations when tracing transactions

### DIFF
--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -47,6 +47,8 @@ module NewRelic
     #
 
     module MethodTracer
+      EMPTY_HASH = {}.freeze
+
       def self.included clazz
         clazz.extend ClassMethods
       end
@@ -67,7 +69,7 @@ module NewRelic
       #
       # @api public
       #
-      def trace_execution_scoped(metric_names, options={}) #THREAD_LOCAL_ACCESS
+      def trace_execution_scoped(metric_names, options=EMPTY_HASH) #THREAD_LOCAL_ACCESS
         NewRelic::Agent.record_api_supportability_metric :trace_execution_scoped
         NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(metric_names, options) do
           # Using an implicit block avoids object allocation for a &block param
@@ -83,7 +85,7 @@ module NewRelic
       #
       # @api public
       #
-      def trace_execution_unscoped(metric_names, options={}) #THREAD_LOCAL_ACCESS
+      def trace_execution_unscoped(metric_names, options=EMPTY_HASH) #THREAD_LOCAL_ACCESS
         NewRelic::Agent.record_api_supportability_metric :trace_execution_unscoped
         return yield unless NewRelic::Agent.tl_is_execution_traced?
         t0 = Time.now

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -1,3 +1,4 @@
+
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
@@ -6,10 +7,11 @@ module NewRelic
   module Agent
     module MethodTracerHelpers
       MAX_ALLOWED_METRIC_DURATION = 1_000_000_000 # roughly 31 years
+      EMPTY_HASH = {}.freeze
 
       extend self
 
-      def trace_execution_scoped(metric_names, options={}) #THREAD_LOCAL_ACCESS
+      def trace_execution_scoped(metric_names, options=EMPTY_HASH) #THREAD_LOCAL_ACCESS
         state = NewRelic::Agent::Tracer.state
         return yield unless state.is_execution_traced?
 


### PR DESCRIPTION
Some memory profiling of a Rails application revealed lots of unnecessary hash allocations for default values of `options` hashes. This PR fixes the most egregious that were detected but this gem might benefit from applying this optimization more broadly.