### PR TITLE
Fix race condition in resque worker instrumentation

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -245,6 +245,12 @@ module NewRelic
 
         def stop_event_loop
           @event_loop.stop if @event_loop
+          # Wait the end of the event loop thread.
+          if @worker_thread
+            unless @worker_thread.join(3)
+              ::NewRelic::Agent.logger.error "Event loop thread did not stop whithin 3 seconds"
+            end
+          end
         end
 
         def trap_signals_for_litespeed

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -248,7 +248,7 @@ module NewRelic
           # Wait the end of the event loop thread.
           if @worker_thread
             unless @worker_thread.join(3)
-              ::NewRelic::Agent.logger.error "Event loop thread did not stop whithin 3 seconds"
+              ::NewRelic::Agent.logger.error "Event loop thread did not stop within 3 seconds"
             end
           end
         end

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -43,6 +43,9 @@ DependencyDetection.defer do
               perform_without_instrumentation
             end
           ensure
+            # Stopping the event loop before flushing the pipe.
+            # The goal is to avoid conflict during write.
+            NewRelic::Agent.agent.stop_event_loop
             NewRelic::Agent.agent.flush_pipe_data
           end
         end


### PR DESCRIPTION
We had a lot of `ERROR : Failure unmarshalling message from Resque child process` errors on our production platform. After looking around we finally found a race condition in the resque instrumentation between the worker loop and the flush process.
This patch:
* wait for the real end of the worker loop while closing it
* close the worker loop before flushing the data to the pipe

This patch is running on our production since 24h now, all the unmarshalling errors are gone.

This is related to the ticket 387095.