### PR TITLE
Calculate message size in bytes for unicode characters

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -37,7 +37,7 @@ module NewRelic::Rack
       if (js_to_inject != "") && should_instrument?(env, status, headers)
         response_string = autoinstrument_source(response, headers, js_to_inject)
         if headers.key?(CONTENT_LENGTH)
-          headers[CONTENT_LENGTH] = response_string.size.to_s
+          headers[CONTENT_LENGTH] = response_string.bytesize.to_s
         end
 
         env[ALREADY_INSTRUMENTED_KEY] = true


### PR DESCRIPTION
Content-Length requires to set message size in bytes.
There is an issue to return number of characters which isn't equal to message size when message contains unicode characters. Fix to calculate size in bytes.