### PR TITLE
Fix BrowserMonitoring when response is nil

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -37,7 +37,8 @@ module NewRelic::Rack
       if (js_to_inject != "") && should_instrument?(env, status, headers)
         response_string = autoinstrument_source(response, headers, js_to_inject)
         if headers.key?(CONTENT_LENGTH)
-          headers[CONTENT_LENGTH] = response_string.size.to_s
+          content_length = response_string ? response_string.size : 0
+          headers[CONTENT_LENGTH] = content_length.to_s
         end
 
         env[ALREADY_INSTRUMENTED_KEY] = true

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -201,8 +201,19 @@ EOL
     assert_equal "344", headers["Content-Length"]
   end
 
+  def test_content_length_set_when_response_is_nil
+    original_headers = {
+      "Content-Length" => "0",
+      "Content-Type"   => "text/html"
+    }
+    headers = headers_from_request(original_headers, nil)
+    assert_equal "0", headers["Content-Length"]
+  end
+
   def headers_from_request(headers, content)
-    app = mock('app', :call => [200, headers, [content]])
+    content = Array(content) if content
+
+    app = mock('app', :call => [200, headers, content])
     browser_monitoring = NewRelic::Rack::BrowserMonitoring.new(app)
     _, headers, _ = browser_monitoring.call({})
     headers


### PR DESCRIPTION
This Pull Requests fixes this Issue: https://github.com/newrelic/rpm/issues/323

When the `response_string` is nil, we default to a `CONTENT_LENGTH` of 0