### PR TITLE
add distributed tracing to sidekiq instrumentation

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -65,7 +65,7 @@ DependencyDetection.defer do
         }
       rescue => e
         NewRelic::Agent.logger.error("Failure during deserializing YAML for Sidekiq::Extensions::DelayedClass", e)
-        NewRelic::SidekiqInstrumentation.default_trace_args(msg)
+        NewRelic::SidekiqInstrumentation::Server.default_trace_args(msg)
       end
     end
 

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -26,13 +26,13 @@ DependencyDetection.defer do
           else
             self.class.default_trace_args(msg)
           end
-          trace_info = msg.delete("newrelic")
+          trace_headers = msg.delete(NewRelic::NEWRELIC_KEY)
           
           perform_action_with_newrelic_trace(trace_args) do
             NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(msg['args'], :'job.sidekiq.args',
               NewRelic::Agent::AttributeFilter::DST_NONE)
-              
-            ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(trace_info) if trace_info
+
+            ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, "Other")
             yield
           end
         end
@@ -47,11 +47,15 @@ DependencyDetection.defer do
       end
       class Client
         def call(_worker_class, job, *_)
-          distributed_trace_payload = ::NewRelic::Agent::DistributedTracing.create_distributed_trace_payload
-          distributed_trace_payload = distributed_trace_payload.http_safe if distributed_trace_payload
-          job["newrelic"] = distributed_trace_payload
+          job[NewRelic::NEWRELIC_KEY] = distributed_tracing_headers
           yield
-        end 
+        end
+
+        def distributed_tracing_headers
+          headers = {}
+          ::NewRelic::Agent::DistributedTracing.insert_distributed_trace_headers(headers)
+          headers
+        end
       end
     end
 

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -46,7 +46,7 @@ DependencyDetection.defer do
         end
       end
       class Client
-        def call(worker_class, job, queue, redis_pool)
+        def call(_worker_class, job, *_)
           distributed_trace_payload = ::NewRelic::Agent::DistributedTracing.create_distributed_trace_payload
           distributed_trace_payload = distributed_trace_payload.http_safe if distributed_trace_payload
           job["newrelic"] = distributed_trace_payload


### PR DESCRIPTION
I wanted to test and see how easily distributed tracing support for sidekiq jobs could be added. At the moment it's not doing anything besides storing the trace payload as additional job attribute on the "client" and reading/accepting it in the "server". IMHO this would already be good enough.

Please let me know if or how you'd like to proceed with something like this.