### PR TITLE
Fix Rails 6.1 AR config deprecation warning

### DIFF
--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -70,7 +70,7 @@ module NewRelic
     report_on('OS version'        ) { ::NewRelic::Agent::SystemInfo.os_version             }
     report_on('OS'                ) { ::NewRelic::Agent::SystemInfo.ruby_os_identifier     }
     report_on('Database adapter'  ) do
-      ActiveRecord::Base.configurations[NewRelic::Control.instance.env]['adapter']
+      ActiveRecord::Base.configs_for(env_name: NewRelic::Control.instance.env)['adapter']
     end
     report_on('Framework'       ) { Agent.config[:framework].to_s  }
     report_on('Dispatcher'      ) { Agent.config[:dispatcher].to_s }


### PR DESCRIPTION
Fixes #330 

For details on the deprecation, see https://github.com/rails/rails/pull/38256